### PR TITLE
compile error caused by sublanguage with same integer value.

### DIFF
--- a/intl/localename.c
+++ b/intl/localename.c
@@ -1387,7 +1387,9 @@ gl_locale_name_default (void)
 	switch (sub)
 	  {
 	  case SUBLANG_SINDHI_PAKISTAN: return "sd_PK";
+#if SUBLANG_SINDHI_AFGHANISTAN != SUBLANG_SINDHI_PAKISTAN
 	  case SUBLANG_SINDHI_AFGHANISTAN: return "sd_AF";
+#endif
 	  }
 	return "sd";
       case LANG_SINHALESE: return "si_LK";


### PR DESCRIPTION
I am getting a compile error on the gcc for windows.  The proposed patch fixes the problem for me.  Please let me know if I can help in providing details or testing alternate fixes.

```
gcc -c -DLOCALEDIR=\"/usr/local/share/locale\" -DLOCALE_ALIAS_PATH=\"/usr/local/share/locale\"
BLE_RELOCATABLE=1 -DIN_LIBRARY -DINSTALLDIR=\"/usr/local/lib\" -DNO_XMALLOC -Dset_relocation_pr
CONV=1 -DHAVE_CONFIG_H -I. -I. -I..  -g -O2 -fvisibility=hidden  localename.c
localename.c: In function '_nl_locale_name_default':
localename.c:1390:4: error: duplicate case value
    case SUBLANG_SINDHI_AFGHANISTAN: return "sd_AF";
    ^
localename.c:1389:4: error: previously used here
    case SUBLANG_SINDHI_PAKISTAN: return "sd_PK";
    ^
makefile:215: recipe for target 'localename.o' failed
gmake[2]: *** [localename.o] Error 1
gmake[2]: Leaving directory 'n:/home/ollisg/dev/hunspell/intl'
makefile:531: recipe for target 'all-recursive' failed
gmake[1]: *** [all-recursive] Error 1
gmake[1]: Leaving directory 'N:/home/ollisg/dev/hunspell'
makefile:438: recipe for target 'all' failed
gmake: *** [all] Error 2 
                                                                     all' failedgmake: *** [all] Error 2rsive' failedgmake[1]: *** [all-recursive] Error 1gmake[1]: Leaving directory 'N:/home/ollisg/dev/hunspell'makefile:438: recipe for target 'all' failedgmake: *** [all] Error 2ence to `_imp___ZN8HunspellD1Ev'Hunspell.o:Hunspell.c:(.text+0x1637): undefined reference to `_imp___ZN8HunspellC1EPKcS1_S1_'Hunspell.o:Hunspell.c:(.text+0x1637): undefined reference to `_imp___ZN8HunspellC1EPKcS1_S1_'^ZN:\home\ollisg\perl5\strawberry\x86\5.22.0\lib\perl5\Alien\Hunspell>6-w64-mingw32\lib\libkernel32.a" "N:\lang\perl\strawberry\x86\5.22.0\c\i686-w64-mingw32\lib\libuser32.a" "N:\lang\perl\strawberry\x86\5.22.0\c\i686-w64-mingw32\lib\libgdi32.a" "N:\lang\perl\strawberry\x86\5.22.0\c\i686-w64-mingw32\lib\libwinspool.a" "
```

```
sh-3.1$ gcc --version
gcc.exe (i686-posix-sjlj, built by strawberryperl.com project) 4.9.2
Copyright (C) 2014 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```