### PR TITLE
Proper line endings of test files for testing on Windows

### DIFF
--- a/tests/.gitattributes
+++ b/tests/.gitattributes
@@ -1,1 +1,4 @@
 *.sug text eol=lf 
+*.good text
+*.wrong text
+*.morph text

--- a/tests/.gitattributes
+++ b/tests/.gitattributes
@@ -1,0 +1,1 @@
+*.sug text eol=lf 


### PR DESCRIPTION
This pull request contains only a single .gitattributes file to tell git to set the proper line endings of the test files (.good, .wrong etc.) only locally.

On windows we can run the `make && make check` commands under MSYS + MinGW environment or variants (i use MSYS2 + MinGW64-32 bit). Proper line endings are needed so tests can pass there.

With this change the behavior of git will be different only on windows, on linux everything stays the same.