### PR TITLE
Fix Sindhi sublang codes and case-statements for MinGW

### DIFF
--- a/intl/localename.c
+++ b/intl/localename.c
@@ -612,9 +612,11 @@
 # ifndef SUBLANG_SERBIAN_CYRILLIC
 # define SUBLANG_SERBIAN_CYRILLIC 0x03
 # endif
-# ifndef SUBLANG_SINDHI_PAKISTAN
-# define SUBLANG_SINDHI_PAKISTAN 0x01
+# ifndef SUBLANG_SINDHI_INDIA
+# define SUBLANG_SINDHI_INDIA 0x01
 # endif
+# undef SUBLANG_SINDHI_PAKISTAN
+# define SUBLANG_SINDHI_PAKISTAN 0x02
 # ifndef SUBLANG_SINDHI_AFGHANISTAN
 # define SUBLANG_SINDHI_AFGHANISTAN 0x02
 # endif
@@ -1386,8 +1388,9 @@ gl_locale_name_default (void)
       case LANG_SINDHI:
 	switch (sub)
 	  {
+      case SUBLANG_SINDHI_INDIA: return "sd_IN";
 	  case SUBLANG_SINDHI_PAKISTAN: return "sd_PK";
-	  case SUBLANG_SINDHI_AFGHANISTAN: return "sd_AF";
+	  /*case SUBLANG_SINDHI_AFGHANISTAN: return "sd_AF";*/
 	  }
 	return "sd";
       case LANG_SINHALESE: return "si_LK";


### PR DESCRIPTION
In the Windows API header `winnt.h`, `SUBLANG_SINDHI_PAKISTAN` is now set to 0x02 -- same value as `SUBLANG_SINDHI_AFGHANISTAN` (which is now marked as `// For app compatibility only`). In its place there is now `SUBLANG_SINDHI_INDIA` with value 0x01. Both the Windows Platform SDK (going back to at least v7.1A) and MinGW have had this update.

The updated values are causing a compilation error `intl/localename.c`, which still assumes `SUBLANG_SINDHI_AFGHANISTAN` and `SUBLANG_SINDHI_PAKISTAN` to have distinct values. I'm getting this error with GCC v5.3.0 (x86_64-posix-seh-rev0) in MinGW-w64 (on Windows 7).

```
localename.c: In function '_nl_locale_name_default':
localename.c:1390:4: error: duplicate case value
    case SUBLANG_SINDHI_AFGHANISTAN: return "sd_AF";
    ^
localename.c:1389:4: error: previously used here
    case SUBLANG_SINDHI_PAKISTAN: return "sd_PK";
    ^
make[2]: *** [Makefile:215: localename.o] Error 1
```

This PR fixes the compilation error in the same way as https://lists.gnu.org/archive/html/bug-gnulib/2008-04/msg00223.html.