### PR TITLE
Ignore binary build products in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ hunspell.pc
 libtool
 stamp-h1
 hunspell-*.tar.gz
+*.exe
+*.o
+*.a
+*~


### PR DESCRIPTION
This keeps the `git status` list cleaner than what it currently is after a build.

I'm not fully familiar with [the intricacies of GNU Autotools](https://en.wikipedia.org/wiki/GNU_Build_System#Components), so for now I'm leaving out the auto-updated or auto-generated `*.in`, `aclocal.m4`, `*.h`, `*.c` and `*.sed` files from the `.gitignore` list.