### PR TITLE
Fix MinGW-w64 build errors for the "libhunspell.a" target

### DIFF
--- a/src/win_api/Makefile.cygwin
+++ b/src/win_api/Makefile.cygwin
@@ -86,7 +86,7 @@ clean:
 
 distclean:	clean
 
-hunspell.hxx:
+hunspell.hxx license.hunspell:
 	ln -s $(OBJ)/*xx $(OBJ)/hunspell.h $(OBJ)/license* $(OBJ2)/*xx ./
 	ln -s $(OBJ)/hunvisapi.h ./
 	ln -s  $(OBJ3)/hunspell.cxx ./hunspellprg.cxx

--- a/src/win_api/Makefile.cygwin
+++ b/src/win_api/Makefile.cygwin
@@ -17,8 +17,8 @@
 
 #CC=gcc 
 #CXX=g++
-CC=gcc -mno-cygwin -DHUNSPELL_STATIC
-CXX=g++ -mno-cygwin -DHUNSPELL_STATIC
+CC=gcc -DHUNSPELL_STATIC
+CXX=g++ -DHUNSPELL_STATIC
 
 CXXFLAGS= -O2 -ansi -pedantic -I.
 #CXXFLAGS= -O2 -Wall -ansi -pedantic -I.

--- a/src/win_api/Makefile.cygwin
+++ b/src/win_api/Makefile.cygwin
@@ -87,13 +87,13 @@ clean:
 
 distclean:	clean
 
-hunspell.hxx license.hunspell:
+$(notdir $(wildcard $(OBJ)/*xx $(OBJ)/license* $(OBJ2)/*xx)) \
+hunspell.h hunvisapi.h hunspellprg.cxx hunzipprg.cxx example.cxx hzip.cxx:
 	ln -s $(OBJ)/*xx $(OBJ)/hunspell.h $(OBJ)/license* $(OBJ2)/*xx ./
 	ln -s $(OBJ)/hunvisapi.h ./
 	ln -s  $(OBJ3)/hunspell.cxx ./hunspellprg.cxx
 	ln -s  $(OBJ3)/hunzip.cxx ./hunzipprg.cxx
 	ln -s  $(OBJ3)/example.cxx $(OBJ3)/hzip.cxx ./
-	make -f Makefile.cygwin
 
 depend:
 	makedepend -- $(CXXFLAGS) -- *.[ch]xx

--- a/src/win_api/Makefile.cygwin
+++ b/src/win_api/Makefile.cygwin
@@ -53,7 +53,9 @@ textparser.o \
 firstparser.o \
 htmlparser.o \
 latexparser.o \
-manparser.o
+manparser.o \
+xmlparser.o \
+odfparser.o
 
 all: hunspell example hzip hunzip 
 
@@ -134,6 +136,7 @@ hunspell.o: atypes.hxx w_char.hxx baseaffix.hxx phonet.hxx suggestmgr.hxx
 hunspellprg.o: config.h hunspell.hxx hashmgr.hxx htypes.hxx filemgr.hxx
 hunspellprg.o: hunzip.hxx affixmgr.hxx atypes.hxx w_char.hxx baseaffix.hxx
 hunspellprg.o: latexparser.hxx manparser.hxx firstparser.hxx
+hunspellprg.o: xmlparser.hxx odfparser.hxx
 hunzip.o: hunzip.hxx
 latexparser.o: ../hunspell/csutil.hxx w_char.hxx latexparser.hxx
 latexparser.o: textparser.hxx

--- a/src/win_api/Makefile.cygwin
+++ b/src/win_api/Makefile.cygwin
@@ -81,7 +81,7 @@ hzip: hzip.o
 	$(CXX) $(CXXFLAGS) -c $<
 
 clean:
-	rm -f *.exe *xx license* license* hunspell.h hzip.c *prg.cxx \
+	rm -f *.exe *xx license* license* hunspell.h hzip.cxx *prg.cxx \
 	*.o *~ example hunspell hzip hunzip libhunspell.a libparser.a
 
 distclean:	clean
@@ -91,7 +91,7 @@ hunspell.hxx license.hunspell:
 	ln -s $(OBJ)/hunvisapi.h ./
 	ln -s  $(OBJ3)/hunspell.cxx ./hunspellprg.cxx
 	ln -s  $(OBJ3)/hunzip.cxx ./hunzipprg.cxx
-	ln -s  $(OBJ3)/example.cxx $(OBJ3)/hzip.c ./
+	ln -s  $(OBJ3)/example.cxx $(OBJ3)/hzip.cxx ./
 	make -f Makefile.cygwin
 
 depend:

--- a/src/win_api/Makefile.cygwin
+++ b/src/win_api/Makefile.cygwin
@@ -82,7 +82,8 @@ hzip: hzip.o
 
 clean:
 	rm -f *.exe *xx license* license* hunspell.h hzip.cxx *prg.cxx \
-	*.o *~ example hunspell hzip hunzip libhunspell.a libparser.a
+	*.o *~ example hunspell hzip hunzip libhunspell.a libparser.a \
+	hunvisapi.h
 
 distclean:	clean
 


### PR DESCRIPTION
I was trying to build and obtain `libhunspell.a` in a MSYS2 / MinGW-w64 environment, using the latest "master" branch (Git commit 53db97279). My commands were the following in a "MinGW-w64 Win64 Shell" window (as installed by MSYS2):

```
cd src/win_api
mingw32-make -f Makefile.cygwin libhunspell.a
```

>**NOTE:** The reason I am explicitly specifying the `libhunspell.a` target is to avoid trying to build `hunspell` -> `hunspellprg.o`, which fails when compiling `hunspellprg.cxx` due to MinGW not providing an implementation of the POSIX `mkdtemp()` function. As an alternative workaround, I could have set the `WIN32` compilation flag like:
>
>```
>mingw32-make -f Makefile.cygwin \
>    CC="gcc -DHUNSPELL_STATIC -DWIN32" \
>    CXX="g++ -DHUNSPELL_STATIC -DWIN32"
>```
>
>to avoid the `mkdtemp()` call, but it still encounters another series of errors when linking `hunspell` due to missing dependencies on `ODFParser` and `XMLParser`. Will fix that separately.

Here are the build errors I encountered when specifying the `libhunspell.a` target, along with my understanding of the root causes and my proposed fixes:

- >mingw32-make: *** No rule to make target 'license.hunspell', needed by 'affentry.o'.  Stop.

    The `license.hunspell` file is usually symlinked from `src/hunspell/license.hunspell` to `src/win_api/license.hunspell` as part of the rule for making `hunspell.hxx`. This works if the default `all` target is being made **without parallelization**, because `all` -> `hunspell` has `hunspellprg.o` listed before `$(LIBS)` (i.e. `libhunspell.a`) -- so the recipe for `hunspell.hxx` (which is a prerequisite of `hunspellprg.o` as listed in the `makedepend` section at the bottom of the `Makefile.cygwin` file) is executed before the recipe for `libhunspell.a` is executed.

    Unfortunately this implicit dependency causes the build to fail if only `libhunspell.a` was requested in the GNU Make command line, because the `license.hunspell` symlink doesn't get created as `hunspellprg.o` is not needed here.

    Fixed this problem by changing the target of the `hunspell.hxx` recipe from just that file to the full list of symlinked files. This also enabled us to eliminate the recursive `make` invocation, because the list of targets will be correctly expanded at makefile-parsing stage.

- >ln: failed to create symbolic link './hzip.c': No such file or directory

    This command (for symlinking `src/tools/hzip.c` into the `src/win_api` directory) in the recipe for `hunspell.hxx` seems to be mistaken. There is no file called `hzip.c` in the `src/tools` directory. The closest match is `hzip.cxx`, which would be used by the `%.o: %.cxx` pattern rule after being symlinked.

    This error would occur only the first time (because `hunspell.hxx` had already been symlinked at an earlier step). Re-trying the `mingw32-make` command would continue, but the build would likely fail at a later step (e.g. when `hzip.cxx` couldn't be found).

    Fixed this problem by replacing all mentions of `hzip.c` in `Makefile.cygwin` with `hzip.cxx`.

- >g++.exe: error: unrecognized command line option '-mno-cygwin'; did you mean '-mno-clwb'?

    The `-mno-cygwin` command-line option has long been deprecated, and has now been removed in the latest GCC versions (I'm using version 6.2.0). (In the GCC 4.x series, for example, the option seems to have been removed somewhere between [version 4.5.4](https://gcc.gnu.org/onlinedocs/gcc-4.5.4/gcc/i386-and-x86_002d64-Windows-Options.html) and [version 4.8.4](https://gcc.gnu.org/onlinedocs/gcc-4.8.4/gcc/i386-and-x86-64-Windows-Options.html).)

    Fixed this error for MinGW builds by removing the `-mno-cygwin` options in `Makefile.cygwin`.

    There is some discussion in [this message thread](http://www.sourceware.org/ml/cygwin/2007-02/msg00079.html), which suggests that after the removal we should run `i686-pc-mingw-gcc` instead of `gcc -mno-cygwin` under Cygwin (and similarly `i686-pc-mingw-g++` instead of `g++ -mno-cygwin`) to avoid the dependency on `cygwin1.dll`. While I haven't tested this out under Cygwin as I don't have a Cygwin installation right now, if this approach works then the Cygwin-free build instructions will also need updating to specify `CC=i686-pc-mingw-gcc CXX=i686-pc-mingw-g++` in the GNU Make command line.