### PR TITLE
Hunspell Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,75 @@
+#
+# hunspell minimalistic Dockerfile
+# @author Loreto Parisi (loretoparisi at gmail dot com)
+# @2016
+#
+
+FROM ubuntu:16.04
+
+MAINTAINER Loreto Parisi loretoparisi@gmail.com
+
+# packages list
+RUN \
+	apt-get update && apt-get install -y \
+# build deps
+	autoconf \
+	automake \
+# hunspell deps
+	libtool \
+	libc6-dev \
+	gcc \
+	g++ \
+	build-essential \
+# git
+	git
+
+# hunspell
+RUN \
+	git clone --depth 1 -b v1.5.3 https://github.com/hunspell/hunspell.git && \
+	cd hunspell && \
+	autoreconf --install && \
+	automake --add-missing && \
+	./configure && \
+	make && \
+	make install && \
+	ldconfig && \
+	make check
+
+# hunspell dict
+RUN \	
+	git clone --depth 1 -o 7b0f312495f8461b456657e4a3465f82ce2bbd8a https://github.com/wooorm/dictionaries.git && \
+# create hunspell dictionaries dir
+	mkdir /usr/share/myspell/ && \
+	mkdir /usr/share/myspell/dicts && \
+# temporary remove specific dictionaries not able to filter
+# to be removed as soon as the regex below will be fixed/improved
+	rm -rf dictionaries/dictionaries/ca_ES-valencia/ && \
+	rm -rf dictionaries/dictionaries/sr_RS-Latn/ && \
+	rm -rf dictionaries/dictionaries/ca_ES-valencia/ && \
+	rm -rf dictionaries/dictionaries/sr_RS-Latn/ && \
+# copy dictionaries
+# see http://stackoverflow.com/questions/40878887/regex-in-sed-to-match-a-subpath-in-a-path-with-capturing-groups
+	for file in dictionaries/dictionaries/**/*.{dic,aff}; do echo $file | sed 's:.*\([a-z][a-z][_-][A-Z][A-Z]\)/index\(.*\):cp & myDicts/\1\2:' | sh; done
+	
+
+# workaround link static lib
+# not needed anymore when using `ldconfig`
+# @see https://github.com/hunspell/hunspell/issues/435
+#RUN \ 
+#	cd /usr/lib/x86_64-linux-gnu && \
+#	ln -s /usr/local/lib/libhunspell-1.5.so.0 .
+
+# check binaries
+RUN \
+# check version
+	hunspell -v && \
+# check dictionaries loaded
+	hunspell -D
+
+# set working directory
+WORKDIR /root
+
+# defaults command
+CMD ["bash"]
+
+


### PR DESCRIPTION
I have created a `Dockerfile` for hunspell to take advantage of cached docker layers and to execute hunspell build and run in different environments.

To build the docker image from the Dockerfile folder you do

```
docker build -t hunspell .
```

This will build all layers, cache each of them with a opportunist caching of git repositories for hunspell and dictionaries stable branches.

Then to run the container in interactive mode (bash) you do

```
docker run --rm -it --name hunspell hunspell bash
```

resulting in

```
$ docker run --rm -it --name hunspell hunspell2 bash
root@27882a6508a7:~# echo "hallo how are yu?" | hunspell
Hunspell 1.5.3
& hallo 10 0: hall, halo, halloo, hallow, hello, halls, Gallo, hall o, Hall, Halon
*
*
& yu 15 14: yew, y, u, you, yum, yup, yuk, ye, ya, nu, yr, yo, cu, yd, mu

root@27882a6508a7:~# 
```

Those instruction should be added to the `README.md` in a `Docker section` (contribution mention will be glad).

