### PR TITLE
Fixes hunspell/hunspell#440

### DIFF
--- a/src/tools/hunspell.cxx
+++ b/src/tools/hunspell.cxx
@@ -88,6 +88,13 @@
 #define DIRSEP "\\"
 #define PATHSEP ";"
 
+#ifdef __MINGW32__
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <unistd.h>
+#endif
+
 #include "textparser.hxx"
 #include "htmlparser.hxx"
 #include "latexparser.hxx"
@@ -1706,7 +1713,7 @@ char* exist2(char* dir, int len, const char* name, const char* ext) {
   return NULL;
 }
 
-#ifndef WIN32
+#if !defined(WIN32) || defined(__MINGW32__)
 int listdicpath(char* dir, int len) {
   std::string buf;
   const char* sep = (len == 0) ? "" : DIRSEP;
@@ -1741,7 +1748,7 @@ char* search(char* begin, char* name, const char* ext) {
     if (name) {
       res = exist2(begin, end - begin, name, ext);
     } else {
-#ifndef WIN32
+#if !defined(WIN32) || defined(__MINGW32__)
       listdicpath(begin, end - begin);
 #endif
     }


### PR DESCRIPTION
Hi Dimitrij,

Your hint was spot on! Incorporating Alexey's patch from https://github.com/Alexpux/MINGW-packages/blob/master/mingw-w64-hunspell/0005-windows-sub-dicts-paths.patch solved the issue and all provided dictionaries are correctly listed as available also on my Windows 10 system now (see screenshot).

![hunspell_availabledictionaries_02](https://cloud.githubusercontent.com/assets/21695902/20986571/503279a4-bcb0-11e6-9509-eb4b29eefa61.jpg)

Thanks for your support! As suggested I have created a pull request to incorporate the changes into Hunspell's master branch.