### PR TITLE
Adding Buffer Interface For Projects that are filesystem averse

### DIFF
--- a/src/hunspell/Makefile.am
+++ b/src/hunspell/Makefile.am
@@ -3,11 +3,12 @@ libhunspell_1_5_includedir = $(includedir)/hunspell
 libhunspell_1_5_la_SOURCES=affentry.cxx affixmgr.cxx csutil.cxx \
 		     hashmgr.cxx hunspell.cxx \
 	             suggestmgr.cxx license.myspell license.hunspell \
-	             phonet.cxx filemgr.cxx hunzip.cxx replist.cxx \
+	             phonet.cxx filemgr.cxx hunzip.cxx replist.cxx  strmgr.cxx \
 	             affentry.hxx htypes.hxx affixmgr.hxx \
 	             csutil.hxx atypes.hxx suggestmgr.hxx \
 	             baseaffix.hxx hashmgr.hxx langnum.hxx \
-	             phonet.hxx filemgr.hxx hunzip.hxx replist.hxx
+	             phonet.hxx filemgr.hxx hunzip.hxx replist.hxx \
+	             strmgr.hxx
 
 libhunspell_1_5_include_HEADERS=hunspell.hxx hunspell.h hunvisapi.h \
 		                w_char.hxx atypes.hxx csutil.hxx htypes.hxx

--- a/src/hunspell/affixmgr.cxx
+++ b/src/hunspell/affixmgr.cxx
@@ -256,7 +256,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key, bool isbuffer) {
   int firstline = 1;
 
   // open the affix file
-  IStrMgr* afflst = isbuffer ? dynamic_cast<IStrMgr*>(new StrMgr(affpath, key)) : dynamic_cast<IStrMgr*>(new FileMgr(affpath, key));
+  IStrMgr* afflst = isbuffer ? dynamic_cast<IStrMgr*>(new StrMgr(affpath)) : dynamic_cast<IStrMgr*>(new FileMgr(affpath, key));
   if (!afflst) {
     HUNSPELL_WARNING(
         stderr, "error: could not open affix description file %s\n", affpath);

--- a/src/hunspell/affixmgr.cxx
+++ b/src/hunspell/affixmgr.cxx
@@ -89,7 +89,8 @@
 
 AffixMgr::AffixMgr(const char* affpath,
                    const std::vector<HashMgr*>& ptr,
-                   const char* key)
+                   const char* key,
+                   bool isbuffer)	
   : alldic(ptr)
   , pHMgr(ptr[0]) {
 
@@ -170,7 +171,7 @@ AffixMgr::AffixMgr(const char* affpath,
     contclasses[j] = 0;
   }
 
-  if (parse_file(affpath, key)) {
+  if (parse_file(affpath, key, isbuffer)) {
     HUNSPELL_WARNING(stderr, "Failure loading aff file %s\n", affpath);
   }
 
@@ -236,7 +237,7 @@ AffixMgr::~AffixMgr() {
 #endif
 }
 
-void AffixMgr::finishFileMgr(FileMgr* afflst) {
+void AffixMgr::finishIStrMgr(IStrMgr* afflst) {
   delete afflst;
 
   // convert affix trees to sorted list
@@ -245,7 +246,7 @@ void AffixMgr::finishFileMgr(FileMgr* afflst) {
 }
 
 // read in aff file and build up prefix and suffix entry objects
-int AffixMgr::parse_file(const char* affpath, const char* key) {
+int AffixMgr::parse_file(const char* affpath, const char* key, bool isbuffer) {
 
   // checking flag duplication
   char dupflags[CONTSIZE];
@@ -255,7 +256,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
   int firstline = 1;
 
   // open the affix file
-  FileMgr* afflst = new FileMgr(affpath, key);
+  IStrMgr* afflst = isbuffer ? dynamic_cast<IStrMgr*>(new StrMgr(affpath, key)) : dynamic_cast<IStrMgr*>(new FileMgr(affpath, key));
   if (!afflst) {
     HUNSPELL_WARNING(
         stderr, "error: could not open affix description file %s\n", affpath);
@@ -284,7 +285,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the keyboard string */
     if (line.compare(0, 3, "KEY", 3) == 0) {
       if (!parse_string(line, keystring, afflst->getlinenum())) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -292,7 +293,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the try string */
     if (line.compare(0, 3, "TRY", 3) == 0) {
       if (!parse_string(line, trystring, afflst->getlinenum())) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -300,7 +301,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the name of the character set used by the .dict and .aff */
     if (line.compare(0, 3, "SET", 3) == 0) {
       if (!parse_string(line, encoding, afflst->getlinenum())) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
       if (encoding == "UTF-8") {
@@ -321,7 +322,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the flag used by the controlled compound words */
     if (line.compare(0, 12, "COMPOUNDFLAG", 12) == 0) {
       if (!parse_flag(line, &compoundflag, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -330,12 +331,12 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     if (line.compare(0, 13, "COMPOUNDBEGIN", 13) == 0) {
       if (complexprefixes) {
         if (!parse_flag(line, &compoundend, afflst)) {
-          finishFileMgr(afflst);
+          finishIStrMgr(afflst);
           return 1;
         }
       } else {
         if (!parse_flag(line, &compoundbegin, afflst)) {
-          finishFileMgr(afflst);
+          finishIStrMgr(afflst);
           return 1;
         }
       }
@@ -344,7 +345,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the flag used by compound words */
     if (line.compare(0, 14, "COMPOUNDMIDDLE", 14) == 0) {
       if (!parse_flag(line, &compoundmiddle, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -353,12 +354,12 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     if (line.compare(0, 11, "COMPOUNDEND", 11) == 0) {
       if (complexprefixes) {
         if (!parse_flag(line, &compoundbegin, afflst)) {
-          finishFileMgr(afflst);
+          finishIStrMgr(afflst);
           return 1;
         }
       } else {
         if (!parse_flag(line, &compoundend, afflst)) {
-          finishFileMgr(afflst);
+          finishIStrMgr(afflst);
           return 1;
         }
       }
@@ -367,7 +368,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the data used by compound_check() method */
     if (line.compare(0, 15, "COMPOUNDWORDMAX", 15) == 0) {
       if (!parse_num(line, &cpdwordmax, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -375,7 +376,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the flag sign compounds in dictionary */
     if (line.compare(0, 12, "COMPOUNDROOT", 12) == 0) {
       if (!parse_flag(line, &compoundroot, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -383,7 +384,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the flag used by compound_check() method */
     if (line.compare(0, 18, "COMPOUNDPERMITFLAG", 18) == 0) {
       if (!parse_flag(line, &compoundpermitflag, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -391,7 +392,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the flag used by compound_check() method */
     if (line.compare(0, 18, "COMPOUNDFORBIDFLAG", 18) == 0) {
       if (!parse_flag(line, &compoundforbidflag, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -422,14 +423,14 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
 
     if (line.compare(0, 9, "NOSUGGEST", 9) == 0) {
       if (!parse_flag(line, &nosuggest, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
 
     if (line.compare(0, 14, "NONGRAMSUGGEST", 14) == 0) {
       if (!parse_flag(line, &nongramsuggest, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -437,7 +438,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the flag used by forbidden words */
     if (line.compare(0, 13, "FORBIDDENWORD", 13) == 0) {
       if (!parse_flag(line, &forbiddenword, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -445,7 +446,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the flag used by forbidden words */
     if (line.compare(0, 13, "LEMMA_PRESENT", 13) == 0) {
       if (!parse_flag(line, &lemma_present, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -453,7 +454,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the flag used by circumfixes */
     if (line.compare(0, 9, "CIRCUMFIX", 9) == 0) {
       if (!parse_flag(line, &circumfix, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -461,7 +462,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the flag used by fogemorphemes */
     if (line.compare(0, 14, "ONLYINCOMPOUND", 14) == 0) {
       if (!parse_flag(line, &onlyincompound, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -469,7 +470,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the flag used by `needaffixs' */
     if (line.compare(0, 10, "PSEUDOROOT", 10) == 0) {
       if (!parse_flag(line, &needaffix, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -477,7 +478,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the flag used by `needaffixs' */
     if (line.compare(0, 9, "NEEDAFFIX", 9) == 0) {
       if (!parse_flag(line, &needaffix, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -485,7 +486,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the minimal length for words in compounds */
     if (line.compare(0, 11, "COMPOUNDMIN", 11) == 0) {
       if (!parse_num(line, &cpdmin, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
       if (cpdmin < 1)
@@ -495,7 +496,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the max. words and syllables in compounds */
     if (line.compare(0, 16, "COMPOUNDSYLLABLE", 16) == 0) {
       if (!parse_cpdsyllable(line, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -503,7 +504,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the flag used by compound_check() method */
     if (line.compare(0, 11, "SYLLABLENUM", 11) == 0) {
       if (!parse_string(line, cpdsyllablenum, afflst->getlinenum())) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -517,7 +518,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     if (line.compare(0, 9, "WORDCHARS", 9) == 0) {
       if (!parse_array(line, wordchars, wordchars_utf16,
                        utf8, afflst->getlinenum())) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -527,7 +528,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     if (line.compare(0, 6, "IGNORE", 6) == 0) {
       if (!parse_array(line, ignorechars, ignorechars_utf16,
                        utf8, afflst->getlinenum())) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -535,7 +536,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the typical fault correcting table */
     if (line.compare(0, 3, "REP", 3) == 0) {
       if (!parse_reptable(line, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -543,7 +544,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the input conversion table */
     if (line.compare(0, 5, "ICONV", 5) == 0) {
       if (!parse_convtable(line, afflst, &iconvtable, "ICONV")) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -551,7 +552,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the input conversion table */
     if (line.compare(0, 5, "OCONV", 5) == 0) {
       if (!parse_convtable(line, afflst, &oconvtable, "OCONV")) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -559,7 +560,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the phonetic translation table */
     if (line.compare(0, 5, "PHONE", 5) == 0) {
       if (!parse_phonetable(line, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -567,7 +568,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the checkcompoundpattern table */
     if (line.compare(0, 20, "CHECKCOMPOUNDPATTERN", 20) == 0) {
       if (!parse_checkcpdtable(line, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -575,7 +576,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the defcompound table */
     if (line.compare(0, 12, "COMPOUNDRULE", 12) == 0) {
       if (!parse_defcpdtable(line, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -583,7 +584,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the related character map table */
     if (line.compare(0, 3, "MAP", 3) == 0) {
       if (!parse_maptable(line, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -591,7 +592,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the word breakpoints table */
     if (line.compare(0, 5, "BREAK", 5) == 0) {
       if (!parse_breaktable(line, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -599,7 +600,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the language for language specific codes */
     if (line.compare(0, 4, "LANG", 4) == 0) {
       if (!parse_string(line, lang, afflst->getlinenum())) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
       langnum = get_lang_num(lang);
@@ -614,7 +615,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
 
     if (line.compare(0, 12, "MAXNGRAMSUGS", 12) == 0) {
       if (!parse_num(line, &maxngramsugs, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -624,14 +625,14 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
 
     if (line.compare(0, 7, "MAXDIFF", 7) == 0) {
       if (!parse_num(line, &maxdiff, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
 
     if (line.compare(0, 10, "MAXCPDSUGS", 10) == 0) {
       if (!parse_num(line, &maxcpdsugs, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -651,7 +652,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the flag used by forbidden words */
     if (line.compare(0, 8, "KEEPCASE", 8) == 0) {
       if (!parse_flag(line, &keepcase, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -659,7 +660,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the flag used by `forceucase' */
     if (line.compare(0, 10, "FORCEUCASE", 10) == 0) {
       if (!parse_flag(line, &forceucase, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -667,7 +668,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the flag used by `warn' */
     if (line.compare(0, 4, "WARN", 4) == 0) {
       if (!parse_flag(line, &warn, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -679,7 +680,7 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
     /* parse in the flag used by the affix generator */
     if (line.compare(0, 11, "SUBSTANDARD", 11) == 0) {
       if (!parse_flag(line, &substandard, afflst)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
@@ -701,13 +702,13 @@ int AffixMgr::parse_file(const char* affpath, const char* key) {
         dupflags_ini = 0;
       }
       if (!parse_affix(line, ft, afflst, dupflags)) {
-        finishFileMgr(afflst);
+        finishIStrMgr(afflst);
         return 1;
       }
     }
   }
 
-  finishFileMgr(afflst);
+  finishIStrMgr(afflst);
   // affix trees are sorted now
 
   // now we can speed up performance greatly taking advantage of the
@@ -3620,7 +3621,7 @@ int AffixMgr::get_sugswithdots(void) const {
 }
 
 /* parse flag */
-bool AffixMgr::parse_flag(const std::string& line, unsigned short* out, FileMgr* af) {
+bool AffixMgr::parse_flag(const std::string& line, unsigned short* out, IStrMgr* af) {
   if (*out != FLAG_NULL && !(*out >= DEFAULTFLAGS)) {
     HUNSPELL_WARNING(
         stderr,
@@ -3636,7 +3637,7 @@ bool AffixMgr::parse_flag(const std::string& line, unsigned short* out, FileMgr*
 }
 
 /* parse num */
-bool AffixMgr::parse_num(const std::string& line, int* out, FileMgr* af) {
+bool AffixMgr::parse_num(const std::string& line, int* out, IStrMgr* af) {
   if (*out != -1) {
     HUNSPELL_WARNING(
         stderr,
@@ -3652,7 +3653,7 @@ bool AffixMgr::parse_num(const std::string& line, int* out, FileMgr* af) {
 }
 
 /* parse in the max syllablecount of compound words and  */
-bool AffixMgr::parse_cpdsyllable(const std::string& line, FileMgr* af) {
+bool AffixMgr::parse_cpdsyllable(const std::string& line, IStrMgr* af) {
   int i = 0;
   int np = 0;
   std::string::const_iterator iter = line.begin();
@@ -3698,7 +3699,7 @@ bool AffixMgr::parse_cpdsyllable(const std::string& line, FileMgr* af) {
 }
 
 /* parse in the typical fault correcting table */
-bool AffixMgr::parse_reptable(const std::string& line, FileMgr* af) {
+bool AffixMgr::parse_reptable(const std::string& line, IStrMgr* af) {
   if (parsedrep) {
     HUNSPELL_WARNING(stderr, "error: line %d: multiple table definitions\n",
                      af->getlinenum());
@@ -3795,7 +3796,7 @@ bool AffixMgr::parse_reptable(const std::string& line, FileMgr* af) {
 
 /* parse in the typical fault correcting table */
 bool AffixMgr::parse_convtable(const std::string& line,
-                              FileMgr* af,
+                              IStrMgr* af,
                               RepList** rl,
                               const std::string& keyword) {
   if (*rl) {
@@ -3889,7 +3890,7 @@ bool AffixMgr::parse_convtable(const std::string& line,
 }
 
 /* parse in the typical fault correcting table */
-bool AffixMgr::parse_phonetable(const std::string& line, FileMgr* af) {
+bool AffixMgr::parse_phonetable(const std::string& line, IStrMgr* af) {
   if (phone) {
     HUNSPELL_WARNING(stderr, "error: line %d: multiple table definitions\n",
                      af->getlinenum());
@@ -3981,7 +3982,7 @@ bool AffixMgr::parse_phonetable(const std::string& line, FileMgr* af) {
 }
 
 /* parse in the checkcompoundpattern table */
-bool AffixMgr::parse_checkcpdtable(const std::string& line, FileMgr* af) {
+bool AffixMgr::parse_checkcpdtable(const std::string& line, IStrMgr* af) {
   if (parsedcheckcpd) {
     HUNSPELL_WARNING(stderr, "error: line %d: multiple table definitions\n",
                      af->getlinenum());
@@ -4078,7 +4079,7 @@ bool AffixMgr::parse_checkcpdtable(const std::string& line, FileMgr* af) {
 }
 
 /* parse in the compound rule table */
-bool AffixMgr::parse_defcpdtable(const std::string& line, FileMgr* af) {
+bool AffixMgr::parse_defcpdtable(const std::string& line, IStrMgr* af) {
   if (parseddefcpd) {
     HUNSPELL_WARNING(stderr, "error: line %d: multiple table definitions\n",
                      af->getlinenum());
@@ -4181,7 +4182,7 @@ bool AffixMgr::parse_defcpdtable(const std::string& line, FileMgr* af) {
 }
 
 /* parse in the character map table */
-bool AffixMgr::parse_maptable(const std::string& line, FileMgr* af) {
+bool AffixMgr::parse_maptable(const std::string& line, IStrMgr* af) {
   if (parsedmaptable) {
     HUNSPELL_WARNING(stderr, "error: line %d: multiple table definitions\n",
                      af->getlinenum());
@@ -4283,7 +4284,7 @@ bool AffixMgr::parse_maptable(const std::string& line, FileMgr* af) {
 }
 
 /* parse in the word breakpoint table */
-bool AffixMgr::parse_breaktable(const std::string& line, FileMgr* af) {
+bool AffixMgr::parse_breaktable(const std::string& line, IStrMgr* af) {
   if (parsedbreaktable) {
     HUNSPELL_WARNING(stderr, "error: line %d: multiple table definitions\n",
                      af->getlinenum());
@@ -4456,7 +4457,7 @@ public:
 
 bool AffixMgr::parse_affix(const std::string& line,
                           const char at,
-                          FileMgr* af,
+                          IStrMgr* af,
                           char* dupflags) {
   int numents = 0;  // number of AffEntry structures to parse
 

--- a/src/hunspell/affixmgr.hxx
+++ b/src/hunspell/affixmgr.hxx
@@ -179,7 +179,7 @@ class AffixMgr {
                                // affix)
 
  public:
-  AffixMgr(const char* affpath, const std::vector<HashMgr*>& ptr, const char* key = NULL);
+  AffixMgr(const char* affpath, const std::vector<HashMgr*>& ptr, const char* key = NULL, bool isbuffer = false);
   ~AffixMgr();
   struct hentry* affix_check(const char* word,
                              int len,
@@ -337,21 +337,21 @@ class AffixMgr {
   int get_fullstrip() const;
 
  private:
-  int parse_file(const char* affpath, const char* key);
-  bool parse_flag(const std::string& line, unsigned short* out, FileMgr* af);
-  bool parse_num(const std::string& line, int* out, FileMgr* af);
-  bool parse_cpdsyllable(const std::string& line, FileMgr* af);
-  bool parse_reptable(const std::string& line, FileMgr* af);
+  int parse_file(const char* affpath, const char* key, bool isbuffer = false);
+  bool parse_flag(const std::string& line, unsigned short* out, IStrMgr* af);
+  bool parse_num(const std::string& line, int* out, IStrMgr* af);
+  bool parse_cpdsyllable(const std::string& line, IStrMgr* af);
+  bool parse_reptable(const std::string& line, IStrMgr* af);
   bool parse_convtable(const std::string& line,
-                      FileMgr* af,
+                      IStrMgr* af,
                       RepList** rl,
                       const std::string& keyword);
-  bool parse_phonetable(const std::string& line, FileMgr* af);
-  bool parse_maptable(const std::string& line, FileMgr* af);
-  bool parse_breaktable(const std::string& line, FileMgr* af);
-  bool parse_checkcpdtable(const std::string& line, FileMgr* af);
-  bool parse_defcpdtable(const std::string& line, FileMgr* af);
-  bool parse_affix(const std::string& line, const char at, FileMgr* af, char* dupflags);
+  bool parse_phonetable(const std::string& line, IStrMgr* af);
+  bool parse_maptable(const std::string& line, IStrMgr* af);
+  bool parse_breaktable(const std::string& line, IStrMgr* af);
+  bool parse_checkcpdtable(const std::string& line, IStrMgr* af);
+  bool parse_defcpdtable(const std::string& line, IStrMgr* af);
+  bool parse_affix(const std::string& line, const char at, IStrMgr* af, char* dupflags);
 
   void reverse_condition(std::string&);
   std::string& debugflag(std::string& result, unsigned short flag);
@@ -366,7 +366,7 @@ class AffixMgr {
   int process_pfx_tree_to_list();
   int process_sfx_tree_to_list();
   int redundant_condition(char, const char* strip, int stripl, const char* cond, int);
-  void finishFileMgr(FileMgr* afflst);
+  void finishIStrMgr(IStrMgr* afflst);
 };
 
 #endif

--- a/src/hunspell/filemgr.cxx
+++ b/src/hunspell/filemgr.cxx
@@ -84,8 +84,6 @@ int FileMgr::fail(const char* err, const char* par) {
 }
 
 FileMgr::FileMgr(const char* file, const char* key) : hin(NULL), linenum(0) {
-  in[0] = '\0';
-
   myopen(fin, file, std::ios_base::in);
   if (!fin.is_open()) {
     // check hzipped file

--- a/src/hunspell/hashmgr.cxx
+++ b/src/hunspell/hashmgr.cxx
@@ -483,7 +483,7 @@ struct hentry* HashMgr::walk_hashtable(int& col, struct hentry* hp) const {
 // load a munched word list and build a hash table on the fly
 int HashMgr::load_tables(const char* tpath, const char* key, bool isbuffer) {
   // open dictionary file
-  IStrMgr* dict = isbuffer ? dynamic_cast<IStrMgr*>(new StrMgr(tpath, key)) : dynamic_cast<IStrMgr*>(new FileMgr(tpath, key));
+  IStrMgr* dict = isbuffer ? dynamic_cast<IStrMgr*>(new StrMgr(tpath)) : dynamic_cast<IStrMgr*>(new FileMgr(tpath, key));
   if (dict == NULL)
     return 1;
 
@@ -833,7 +833,7 @@ int HashMgr::load_config(const char* affpath, const char* key, bool isbuffer) {
   int firstline = 1;
 
   // open the affix file
-  IStrMgr* afflst = isbuffer ? dynamic_cast<IStrMgr*>(new StrMgr(affpath, key)) : dynamic_cast<IStrMgr*>(new FileMgr(affpath, key));
+  IStrMgr* afflst = isbuffer ? dynamic_cast<IStrMgr*>(new StrMgr(affpath)) : dynamic_cast<IStrMgr*>(new FileMgr(affpath, key));
   if (!afflst) {
     HUNSPELL_WARNING(
         stderr, "Error - could not open affix description file or there was an error processing the buffer%s\n", affpath);

--- a/src/hunspell/hashmgr.hxx
+++ b/src/hunspell/hashmgr.hxx
@@ -79,6 +79,7 @@
 #include <vector>
 
 #include "htypes.hxx"
+#include "strmgr.hxx"
 #include "filemgr.hxx"
 #include "w_char.hxx"
 
@@ -104,7 +105,7 @@ class HashMgr {
   char** aliasm;
 
  public:
-  HashMgr(const char* tpath, const char* apath, const char* key = NULL);
+  HashMgr(const char* tpath, const char* apath, const char* key = NULL, bool isbuffer = false);
   ~HashMgr();
 
   struct hentry* lookup(const char*) const;
@@ -114,33 +115,33 @@ class HashMgr {
   int add(const std::string& word);
   int add_with_affix(const std::string& word, const std::string& pattern);
   int remove(const std::string& word);
-  int decode_flags(unsigned short** result, const std::string& flags, FileMgr* af) const;
-  bool decode_flags(std::vector<unsigned short>& result, const std::string& flags, FileMgr* af) const;
+  int decode_flags(unsigned short** result, const std::string& flags, IStrMgr* af) const;
+  bool decode_flags(std::vector<unsigned short>& result, const std::string& flags, IStrMgr* af) const;
   unsigned short decode_flag(const char* flag) const;
   char* encode_flag(unsigned short flag) const;
   int is_aliasf() const;
-  int get_aliasf(int index, unsigned short** fvec, FileMgr* af) const;
+  int get_aliasf(int index, unsigned short** fvec, IStrMgr* af) const;
   int is_aliasm() const;
   char* get_aliasm(int index) const;
 
  private:
   int get_clen_and_captype(const std::string& word, int* captype);
-  int load_tables(const char* tpath, const char* key);
+  int load_tables(const char* tpath, const char* key, bool isbuffer);
   int add_word(const std::string& word,
                int wcl,
                unsigned short* ap,
                int al,
                const std::string* desc,
                bool onlyupcase);
-  int load_config(const char* affpath, const char* key);
-  bool parse_aliasf(const std::string& line, FileMgr* af);
+  int load_config(const char* affpath, const char* key, bool isbuffer);
+  bool parse_aliasf(const std::string& line, IStrMgr* af);
   int add_hidden_capitalized_word(const std::string& word,
                                   int wcl,
                                   unsigned short* flags,
                                   int al,
                                   const std::string* dp,
                                   int captype);
-  bool parse_aliasm(const std::string& line, FileMgr* af);
+  bool parse_aliasm(const std::string& line, IStrMgr* af);
   int remove_forbidden_flag(const std::string& word);
 };
 

--- a/src/hunspell/hunspell.cxx
+++ b/src/hunspell/hunspell.cxx
@@ -89,9 +89,9 @@
 class HunspellImpl
 {
 public:
-  HunspellImpl(const char* affpath, const char* dpath, const char* key);
+  HunspellImpl(const char* affpath, const char* dpath, const char* key, bool isbuffer);
   ~HunspellImpl();
-  int add_dic(const char* dpath, const char* key);
+  int add_dic(const char* dpath, const char* key, bool isbuffer);
   std::vector<std::string> suffix_suggest(const std::string& root_word);
   std::vector<std::string> generate(const std::string& word, const std::vector<std::string>& pl);
   std::vector<std::string> generate(const std::string& word, const std::string& pattern);
@@ -153,22 +153,22 @@ private:
   HunspellImpl& operator=(const HunspellImpl&);
 };
 
-Hunspell::Hunspell(const char* affpath, const char* dpath, const char* key)
-  : m_Impl(new HunspellImpl(affpath, dpath, key)) {
+Hunspell::Hunspell(const char* affpath, const char* dpath, const char* key, bool isbuffer)
+  : m_Impl(new HunspellImpl(affpath, dpath, key, isbuffer)) {
 }
 
-HunspellImpl::HunspellImpl(const char* affpath, const char* dpath, const char* key) {
+HunspellImpl::HunspellImpl(const char* affpath, const char* dpath, const char* key, bool isbuffer) {
   csconv = NULL;
   utf8 = 0;
   complexprefixes = 0;
   affixpath = mystrdup(affpath);
 
   /* first set up the hash manager */
-  m_HMgrs.push_back(new HashMgr(dpath, affpath, key));
+  m_HMgrs.push_back(new HashMgr(dpath, affpath, key, isbuffer));
 
   /* next set up the affix manager */
   /* it needs access to the hash manager lookup methods */
-  pAMgr = new AffixMgr(affpath, m_HMgrs, key);
+  pAMgr = new AffixMgr(affpath, m_HMgrs, key, isbuffer);
 
   /* get the preferred try string and the dictionary */
   /* encoding from the Affix Manager for that dictionary */
@@ -211,15 +211,15 @@ HunspellImpl::~HunspellImpl() {
 }
 
 // load extra dictionaries
-int Hunspell::add_dic(const char* dpath, const char* key) {
-  return m_Impl->add_dic(dpath, key);
+int Hunspell::add_dic(const char* dpath, const char* key, bool isbuffer) {
+  return m_Impl->add_dic(dpath, key, isbuffer);
 }
 
 // load extra dictionaries
-int HunspellImpl::add_dic(const char* dpath, const char* key) {
+int HunspellImpl::add_dic(const char* dpath, const char* key, bool isbuffer) {
   if (!affixpath)
     return 1;
-  m_HMgrs.push_back(new HashMgr(dpath, affixpath, key));
+  m_HMgrs.push_back(new HashMgr(dpath, affixpath, key, isbuffer));
   return 0;
 }
 
@@ -1874,7 +1874,7 @@ int Hunspell::generate(char*** slst, const char* word, const char* pattern) {
   return Hunspell_generate((Hunhandle*)(this), slst, word, pattern);
 }
 
-Hunhandle* Hunspell_create(const char* affpath, const char* dpath) {
+Hunhandle* Hunspell_create(const char* affpath, const char* dpath, int isbuffer) {
   return (Hunhandle*)(new Hunspell(affpath, dpath));
 }
 
@@ -1882,6 +1882,10 @@ Hunhandle* Hunspell_create_key(const char* affpath,
                                const char* dpath,
                                const char* key) {
   return reinterpret_cast<Hunhandle*>(new Hunspell(affpath, dpath, key));
+}
+
+Hunhandle* Hunspell_create_buffer(const char* affpath, const char* dpath, const char* key, int isbuffer){
+  return (Hunhandle*)(new Hunspell(affpath, dpath, key, isbuffer));
 }
 
 void Hunspell_destroy(Hunhandle* pHunspell) {

--- a/src/hunspell/hunspell.h
+++ b/src/hunspell/hunspell.h
@@ -56,6 +56,11 @@ LIBHUNSPELL_DLL_EXPORTED Hunhandle* Hunspell_create_key(const char* affpath,
                                                         const char* dpath,
                                                         const char* key);
 
+LIBHUNSPELL_DLL_EXPORTED Hunhandle* Hunspell_create_buffer(const char* affpath,
+                                                        const char* dpath,
+							const char* key,
+							int isbuffer);
+
 LIBHUNSPELL_DLL_EXPORTED void Hunspell_destroy(Hunhandle* pHunspell);
 
 /* load extra dictionaries (only dic files)

--- a/src/hunspell/hunspell.hxx
+++ b/src/hunspell/hunspell.hxx
@@ -112,11 +112,11 @@ class LIBHUNSPELL_DLL_EXPORTED Hunspell {
    * long path names (without the long path prefix Hunspell will use fopen()
    * with system-dependent character encoding instead of _wfopen()).
    */
-  Hunspell(const char* affpath, const char* dpath, const char* key = NULL);
+  Hunspell(const char* affpath, const char* dpath, const char* key = NULL, bool isbuffer = false);
   ~Hunspell();
 
   /* load extra dictionaries (only dic files) */
-  int add_dic(const char* dpath, const char* key = NULL);
+  int add_dic(const char* dpath, const char* key = NULL, bool isbuffer = false);
 
   /* spell(word) - spellcheck word
    * output: false = bad word, true = good word

--- a/src/hunspell/istrmgr.hxx
+++ b/src/hunspell/istrmgr.hxx
@@ -71,31 +71,14 @@
  * SUCH DAMAGE.
  */
 
-/* file manager class - read lines of files [filename] OR [filename.hz] */
-#ifndef FILEMGR_HXX_
-#define FILEMGR_HXX_
+#ifndef ISTRMGR_HXX
+#define ISTRMGR_HXX
+#include <string>
 
-#include "hunzip.hxx"
-#include "istrmgr.hxx" 
-#include <stdio.h>
-#include <fstream>
-
-
-class FileMgr : public IStrMgr {
- private:
-  FileMgr(const FileMgr&);
-  FileMgr& operator=(const FileMgr&);
-
- protected:
-  std::ifstream fin;
-  Hunzip* hin;
-  int fail(const char* err, const char* par);
-  int linenum;
-
- public:
-  FileMgr(const char* filename, const char* key = NULL);
-  virtual ~FileMgr();
-  virtual bool getline(std::string&);
-  virtual int getlinenum();
+class IStrMgr {
+public:
+	virtual ~IStrMgr(){}
+	virtual bool getline(std::string&) = 0;
+	virtual int getlinenum() = 0;
 };
-#endif
+#endif 

--- a/src/hunspell/strmgr.cxx
+++ b/src/hunspell/strmgr.cxx
@@ -73,7 +73,6 @@
 
 
 #include <stdio.h>
-#include <string.h>
 #include "strmgr.hxx"
 
 int StrMgr::fail(const char * err) {

--- a/src/hunspell/strmgr.cxx
+++ b/src/hunspell/strmgr.cxx
@@ -76,23 +76,28 @@
 #include <string.h>
 #include "strmgr.hxx"
 
-int StrMgr::fail(const char * err, const char * par) {
-  fprintf(stderr, err, par);
+int StrMgr::fail(const char * err) {
+  fprintf(stderr, err);
   return -1;
 }
 
-StrMgr::StrMgr(const char * str, const char * key) {
-  std::string str_copy(str, strlen(str));
-  std::istringstream ss(str_copy);
+StrMgr::StrMgr(const char * str) : linenum(0), error(false) {
+  if (!str) {
+    fail("StrMgr: initialized with empty string\n");
+    error = true;
+  } else {
+    ss.str(str);
+  }
 }
 
 StrMgr::~StrMgr() {}
 
 bool StrMgr::getline(std::string& dest) {
-  bool ret = static_cast<bool>(std::getline(ss, dest));
-  if (ret) {
+  bool ret = false;
+  if (!error)
+    ret = static_cast<bool>(std::getline(ss, dest));
+  if (!ret)
     linenum++;
-  }
   return ret;
 }
 

--- a/src/hunspell/strmgr.cxx
+++ b/src/hunspell/strmgr.cxx
@@ -71,31 +71,31 @@
  * SUCH DAMAGE.
  */
 
-/* file manager class - read lines of files [filename] OR [filename.hz] */
-#ifndef FILEMGR_HXX_
-#define FILEMGR_HXX_
 
-#include "hunzip.hxx"
-#include "istrmgr.hxx" 
 #include <stdio.h>
-#include <fstream>
+#include <string.h>
+#include "strmgr.hxx"
 
+int StrMgr::fail(const char * err, const char * par) {
+  fprintf(stderr, err, par);
+  return -1;
+}
 
-class FileMgr : public IStrMgr {
- private:
-  FileMgr(const FileMgr&);
-  FileMgr& operator=(const FileMgr&);
+StrMgr::StrMgr(const char * str, const char * key) {
+  std::string str_copy(str, strlen(str));
+  std::istringstream ss(str_copy);
+}
 
- protected:
-  std::ifstream fin;
-  Hunzip* hin;
-  int fail(const char* err, const char* par);
-  int linenum;
+StrMgr::~StrMgr() {}
 
- public:
-  FileMgr(const char* filename, const char* key = NULL);
-  virtual ~FileMgr();
-  virtual bool getline(std::string&);
-  virtual int getlinenum();
-};
-#endif
+bool StrMgr::getline(std::string& dest) {
+  bool ret = static_cast<bool>(std::getline(ss, dest));
+  if (ret) {
+    linenum++;
+  }
+  return ret;
+}
+
+int StrMgr::getlinenum() {
+  return linenum;
+}

--- a/src/hunspell/strmgr.hxx
+++ b/src/hunspell/strmgr.hxx
@@ -71,31 +71,25 @@
  * SUCH DAMAGE.
  */
 
-/* file manager class - read lines of files [filename] OR [filename.hz] */
-#ifndef FILEMGR_HXX_
-#define FILEMGR_HXX_
+#ifndef STRMGR_HXX_
+#define STRMGR_HXX_
 
 #include "hunzip.hxx"
-#include "istrmgr.hxx" 
-#include <stdio.h>
-#include <fstream>
+#include "istrmgr.hxx"
+#include <sstream>
+#include <string>
 
+class StrMgr : public IStrMgr {
+protected:
+	std::istringstream ss;
+	std::string str_copy;
+	int fail(const char * err,const char * par);
+	int linenum;
 
-class FileMgr : public IStrMgr {
- private:
-  FileMgr(const FileMgr&);
-  FileMgr& operator=(const FileMgr&);
-
- protected:
-  std::ifstream fin;
-  Hunzip* hin;
-  int fail(const char* err, const char* par);
-  int linenum;
-
- public:
-  FileMgr(const char* filename, const char* key = NULL);
-  virtual ~FileMgr();
-  virtual bool getline(std::string&);
-  virtual int getlinenum();
+public:
+	StrMgr(const char * str, const char * key = NULL);
+	virtual ~StrMgr();
+	virtual bool getline(std::string&);
+	virtual int getlinenum();
 };
 #endif

--- a/src/hunspell/strmgr.hxx
+++ b/src/hunspell/strmgr.hxx
@@ -82,12 +82,11 @@
 class StrMgr : public IStrMgr {
 protected:
 	std::istringstream ss;
-	std::string str_copy;
-	int fail(const char * err,const char * par);
+	int fail(const char * err);
 	int linenum;
-
+	bool error;
 public:
-	StrMgr(const char * str, const char * key = NULL);
+	StrMgr(const char * str);
 	virtual ~StrMgr();
 	virtual bool getline(std::string&);
 	virtual int getlinenum();

--- a/src/hunspell/strmgr.hxx
+++ b/src/hunspell/strmgr.hxx
@@ -74,10 +74,8 @@
 #ifndef STRMGR_HXX_
 #define STRMGR_HXX_
 
-#include "hunzip.hxx"
 #include "istrmgr.hxx"
 #include <sstream>
-#include <string>
 
 class StrMgr : public IStrMgr {
 protected:


### PR DESCRIPTION
A little history on this PR:
I made an attempt at this work several years ago and tried to patch it back to the project (back when it was in sourceforge). Whomever was maintaining said he/she liked the patch, but wanted me to write tests for the work. I asked for some direction, but never heard back. I had done the work specifically to enable folks needing a distributed spellchecker in a server setting using a datastore (rather than a filesystem).
The work was particularly done for the ["nodehun" nodeJS project](https://www.npmjs.com/package/nodehun), which has a fair number of users.

What's it for?
The point of this work is to allow raw buffers to be passed into Hunspell initialization rather than filepaths. It makes the assumption that the file isn't "zipped" in the hunzip extension. Maybe in the future someone can do the work to pass the `StrMgr` class to the `Hunzip` class rather than a filepath, and we could get rid of the `FileMgr` class altogether.

Why now?
The nodehun project maintainers would like to use the main hunspell repository rather than my crappy fork which hasn't kept up with any changes.

Thanks,
Nathan Sweet