### PR TITLE
Add 'pkg-config' to the list of macOS packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ In Ubuntu, the packages are:
 On macOS for compiler always use `clang` and not `g++` because Homebrew
 dependencies are build with that.
 
-    brew install autoconf automake libtool gettext cppunit
+    brew install autoconf automake libtool gettext pkg-config cppunit
     brew link gettext --force
 
 Then run the standard trio: autoreconf, configure, make. See above.


### PR DESCRIPTION
I needed to install the `pkg-config` Homebrew package on macOS 10.12.6, otherwise the `configure` script was encountering this syntax error:

>./configure: line 17377: syntax error near unexpected token `CPPUNIT,'

>./configure: line 17377: `PKG_CHECK_MODULES(CPPUNIT, cppunit >= 1.11.6)'

Doing a `autoreconf -vfi` after installing the `pkg-config` package fixed the issue in the `configure` script.