### PR TITLE
Fix assumption of clock_t being integral

### DIFF
--- a/src/hunspell/suggestmgr.hxx
+++ b/src/hunspell/suggestmgr.hxx
@@ -28,7 +28,7 @@
 #define MAXCOMPOUNDSUGS 3
 
 // timelimit: max ~1/4 sec (process time on Linux) for a time consuming function
-#define TIMELIMIT (CLOCKS_PER_SEC >> 2)
+#define TIMELIMIT (CLOCKS_PER_SEC / 4)
 #define MINTIMER 100
 #define MAXPLUSTIMER 100
 


### PR DESCRIPTION
`CLOCKS_PER_SEC` is of type `clock_t`, defined in `<time.h>`. The C standard has historically always specified `clock_t` to be [simply an *arithmetic* type, which allows it to be floating-point](http://en.cppreference.com/w/c/chrono/clock_t). C11 actually mandates it be a floating-point type. (C++ has picked up on the pre-C11 definition and doesn't require it be floating-point, but allows it to be.)

The definition of `TIMELIMIT` (in `suggestmgr.hxx`) assumes that `CLOCKS_PER_SEC` is of integral type. I found one platform -- [Embarcadero C++Builder](https://www.embarcadero.com/products/cbuilder) (which uses Dinkumware's standard library) -- in which this code encounters a compile error.

**> bcc32c suggestmgr.cxx**
```
Embarcadero C++ 7.30 for Win32 Copyright (c) 2012-2017 Embarcadero Technologies, Inc.
suggestmgr.cxx:
suggestmgr.cxx:1481:36: error: invalid operands to binary expression ('double' and 'int')
      if ((clock() - *timelimit) > TIMELIMIT)
                                   ^~~~~~~~~
./suggestmgr.hxx:31:35: note: expanded from macro 'TIMELIMIT'
#define TIMELIMIT (CLOCKS_PER_SEC >> 2)
                   ~~~~~~~~~~~~~~ ^  ~
1 error generated.
```

Fix the definition of `TIMELIMIT` to allow `CLOCKS_PER_SEC` to be non-integral.