### PR TITLE
Mention copyright holder of phonet.cc in AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,6 @@ See also <https://github.com/hunspell/hunspell/graphs/contributors>
 
 Hunspell is based on OpenOffice.org's Myspell. MySpell's author:
 * 2001-2002, Kevin Hendricks
+
+Replacement algorithms for phonetic transformation:
+* 2000, 2007 Bjoern Jacke


### PR DESCRIPTION
This is a bit silly, but my downstream repository maintainers mandate that all copyright holders with a `(c)` or `copyright` comment in the source files get named in the `AUTHORS` file.