### PR TITLE
Fix MSVC compilation and warnings

### DIFF
--- a/msvc/hunspell.vcxproj
+++ b/msvc/hunspell.vcxproj
@@ -96,7 +96,7 @@
       <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <DisableSpecificWarnings>4127;4706</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4127;4267;4706</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -118,7 +118,7 @@
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
-      <DisableSpecificWarnings>4127;4706</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4127;4267;4706</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -139,7 +139,7 @@
       <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat />
-      <DisableSpecificWarnings>4127;4706</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4127;4267;4706</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -164,7 +164,7 @@
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>
       </DebugInformationFormat>
-      <DisableSpecificWarnings>4127;4706</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4127;4267;4706</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/msvc/libhunspell.vcxproj
+++ b/msvc/libhunspell.vcxproj
@@ -171,7 +171,7 @@
       <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <DisableSpecificWarnings>4706</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4706;4251;4267</DisableSpecificWarnings>
     </ClCompile>
     <Lib>
       <AdditionalOptions>/MACHINE:X86 %(AdditionalOptions)</AdditionalOptions>
@@ -192,7 +192,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <DisableSpecificWarnings>4706</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4706;4251;4267</DisableSpecificWarnings>
     </ClCompile>
     <Lib />
   </ItemDefinitionGroup>
@@ -212,7 +212,7 @@
       <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat />
-      <DisableSpecificWarnings>4706</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4706;4251;4267</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -240,7 +240,7 @@
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>
       </DebugInformationFormat>
-      <DisableSpecificWarnings>4706</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4706;4251;4267</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -266,7 +266,7 @@
       <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat />
-      <DisableSpecificWarnings>4706</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4706;4251;4267</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -299,7 +299,7 @@
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>
       </DebugInformationFormat>
-      <DisableSpecificWarnings>4706</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4706;4251;4267</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -330,7 +330,7 @@
       <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <DisableSpecificWarnings>4706</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4706;4251;4267</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -356,7 +356,7 @@
       <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <DisableSpecificWarnings>4706</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4706;4251;4267</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/src/hunspell/affixmgr.cxx
+++ b/src/hunspell/affixmgr.cxx
@@ -2021,9 +2021,9 @@ struct hentry* AffixMgr::compound_check(const std::string& word,
               if (sfxappnd) {
                 std::string tmp(sfxappnd);
                 reverseword(tmp);
-                numsyllable -= get_syllable(tmp) + sfxextra;
+                numsyllable -= short(get_syllable(tmp) + sfxextra);
               } else {
-                numsyllable -= sfxextra;
+                numsyllable -= short(sfxextra);
               }
 
               // + 1 word, if syllable number of the prefix > 1 (hungarian
@@ -2614,9 +2614,9 @@ int AffixMgr::compound_check_morph(const char* word,
           if (sfxappnd) {
             std::string tmp(sfxappnd);
             reverseword(tmp);
-            numsyllable -= get_syllable(tmp) + sfxextra;
+            numsyllable -= short(get_syllable(tmp) + sfxextra);
           } else {
-            numsyllable -= sfxextra;
+            numsyllable -= short(sfxextra);
           }
 
           // + 1 word, if syllable number of the prefix > 1 (hungarian

--- a/src/hunspell/csutil.cxx
+++ b/src/hunspell/csutil.cxx
@@ -69,6 +69,7 @@
  */
 
 #include <algorithm>
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -486,20 +487,17 @@ void uniqlist(std::vector<std::string>& list) {
 
 namespace {
 unsigned char cupper(const struct cs_info* csconv, int nIndex) {
-  if (nIndex < 0 || nIndex > 255)
-    return nIndex;
+  assert(nIndex >= 0 && nIndex <= 255);
   return csconv[nIndex].cupper;
 }
 
 unsigned char clower(const struct cs_info* csconv, int nIndex) {
-  if (nIndex < 0 || nIndex > 255)
-    return nIndex;
+  assert(nIndex >= 0 && nIndex <= 255);
   return csconv[nIndex].clower;
 }
 
 unsigned char ccase(const struct cs_info* csconv, int nIndex) {
-  if (nIndex < 0 || nIndex > 255)
-    return nIndex;
+  assert(nIndex >= 0 && nIndex <= 255);
   return csconv[nIndex].ccase;
 }
 }

--- a/src/hunspell/hunzip.cxx
+++ b/src/hunspell/hunzip.cxx
@@ -178,7 +178,7 @@ int Hunzip::getbuf() {
   do {
     if (inc == 0) {
       fin.read(in, BUFSIZE);
-      inbits = fin.gcount() * 8;
+      inbits = int(fin.gcount() * 8);
     }
     for (; inc < inbits; inc++) {
       int b = (in[inc / 8] & (1 << (7 - (inc % 8)))) ? 1 : 0;

--- a/src/parsers/odfparser.cxx
+++ b/src/parsers/odfparser.cxx
@@ -79,8 +79,8 @@ bool ODFParser::next_token(std::string& t) {
   return XMLParser::next_token(PATTERN, PATTERN_LEN, PATTERN2, PATTERN_LEN2, PATTERN3, PATTERN_LEN3, t);
 }
 
-std::string ODFParser::get_word(const std::string token) {
-  return XMLParser::get_word(PATTERN3, PATTERN_LEN3, token);
+std::string ODFParser::get_word(const std::string &tok) {
+  return XMLParser::get_word(PATTERN3, PATTERN_LEN3, tok);
 }
 
 ODFParser::~ODFParser() {}

--- a/src/parsers/odfparser.hxx
+++ b/src/parsers/odfparser.hxx
@@ -50,7 +50,7 @@ class ODFParser : public XMLParser {
   explicit ODFParser(const char* wc);
   ODFParser(const w_char* wordchars, int len);
   virtual bool next_token(std::string&);
-  virtual std::string get_word(const std::string token);
+  virtual std::string get_word(const std::string &tok);
   virtual ~ODFParser();
 };
 

--- a/src/parsers/textparser.cxx
+++ b/src/parsers/textparser.cxx
@@ -222,8 +222,8 @@ int TextParser::change_token(const char* word) {
   return 0;
 }
 
-std::string TextParser::get_word(const std::string token) {
-  return token;
+std::string TextParser::get_word(const std::string &tok) {
+  return tok;
 }
 
 void TextParser::check_urls() {

--- a/src/parsers/textparser.hxx
+++ b/src/parsers/textparser.hxx
@@ -78,7 +78,7 @@ class TextParser {
   std::string get_line() const;
   std::string get_prevline(int n) const;
   virtual bool next_token(std::string&);
-  virtual std::string get_word(const std::string token);
+  virtual std::string get_word(const std::string &tok);
   virtual int change_token(const char* word);
   void set_url_checking(int check);
 

--- a/src/parsers/xmlparser.cxx
+++ b/src/parsers/xmlparser.cxx
@@ -221,8 +221,8 @@ bool XMLParser::next_token(std::string& t) {
 std::string XMLParser::get_word(
         const char* PATTERN3[][2],
         unsigned int PATTERN_LEN3,
-        const std::string token) {
-  std::string word = token;
+        const std::string &tok) {
+  std::string word = tok;
   for (unsigned int i = 0; i < PATTERN_LEN3; i++) {
     size_t pos;
     while ((pos = word.find(PATTERN3[i][0])) != -1) {

--- a/src/parsers/xmlparser.hxx
+++ b/src/parsers/xmlparser.hxx
@@ -59,7 +59,7 @@ class XMLParser : public TextParser {
   virtual bool next_token(std::string&);
   std::string get_word(const char* p2[][2],
                   unsigned int len2,
-                  const std::string token);
+                  const std::string &tok);
   int change_token(const char* word);
   virtual ~XMLParser();
 

--- a/src/tools/hunspell.cxx
+++ b/src/tools/hunspell.cxx
@@ -46,7 +46,7 @@
 #include <sstream>
 #include <string>
 #include <string.h>
-#include "../../config.h"
+#include <config.h>
 #include "../hunspell/atypes.hxx"
 #include "../hunspell/hunspell.hxx"
 #include "../hunspell/csutil.hxx"
@@ -617,7 +617,7 @@ bool check(Hunspell** pMS, int* d, const std::string& token, int* info, std::str
   return false;
 }
 
-static int is_zipped_odf(TextParser* parser, const char* extension) {
+static bool is_zipped_odf(TextParser* parser, const char* extension) {
   // ODFParser and not flat ODF
   return dynamic_cast<ODFParser*>(parser) && (extension && extension[0] != 'f');
 }
@@ -631,6 +631,7 @@ static bool secure_filename(const char* filename) {
 
 char* mymkdtemp(char *templ) {
 #ifdef WIN32
+  (void)templ;
   char *odftmpdir = tmpnam(NULL);
   if (!odftmpdir) {
     return NULL;
@@ -1740,7 +1741,7 @@ char* search(char* begin, char* name, const char* ext) {
       end++;
     char* res = NULL;
     if (name) {
-      res = exist2(begin, end - begin, name, ext);
+      res = exist2(begin, int(end - begin), name, ext);
     } else {
 #if !defined(WIN32) || defined(__MINGW32__)
       listdicpath(begin, end - begin);


### PR DESCRIPTION
* Suppress size_t -> int warnings
* Avoid implicit cast to shorter integers