### PR TITLE
Exit early on -D with no file args

### DIFF
--- a/src/tools/hunspell.cxx
+++ b/src/tools/hunspell.cxx
@@ -2065,6 +2065,9 @@ int main(int argc, char** argv) {
         gettext(
             "AVAILABLE DICTIONARIES (path is not mandatory for -d option):\n"));
     search(path, NULL, NULL);
+    if (-1 == arg_files) {
+      exit(0);
+    }
   }
 
   if (!privdicname)


### PR DESCRIPTION
When the -D flag is run with no files to process, hunspell defaults to STDIN, which isn't very convenient when you just need a list of available dictionaries and their paths. This change causes it to successfully exit when no files are passed in.

Closes #202 