### PR TITLE
Always initialize HunspellImpl::suggest_internal's out-parameters

### DIFF
--- a/src/hunspell/hunspell.cxx
+++ b/src/hunspell/hunspell.cxx
@@ -971,6 +971,10 @@ std::vector<std::string> HunspellImpl::suggest(const std::string& word) {
 
 std::vector<std::string> HunspellImpl::suggest_internal(const std::string& word,
         bool& capwords, size_t& abbv, int& captype) {
+  captype = NOCAP;
+  abbv = 0;
+  capwords = false;
+
   std::vector<std::string> slst;
 
   int onlycmpdsug = 0;
@@ -988,8 +992,6 @@ std::vector<std::string> HunspellImpl::suggest_internal(const std::string& word,
     if (word.size() >= MAXWORDLEN)
       return slst;
   }
-  captype = NOCAP;
-  abbv = 0;
   size_t wl = 0;
 
   std::string scw;
@@ -1010,7 +1012,6 @@ std::vector<std::string> HunspellImpl::suggest_internal(const std::string& word,
       return slst;
   }
 
-  capwords = false;
   bool good = false;
 
   clock_t timelimit;


### PR DESCRIPTION
...that were introduced with 3f00ff33e8cde1922d3cacf0b0b1476cbc8cab16
"[suggestion] tdf#118162 time limit for a HunspellImpl::suggest() call".

HunspellImpl::suggest could use capwords uninitialized at
src/hunspell/hunspell.cxx:897 when its call to HunspellImpl::suggest_internal
had returned early, before initialising its capwords out-parameter.

(Found with the copy of Hunspell in LibreOffice, see
<https://gerrit.libreoffice.org/#/c/62345/> "Fix
external/hunspell/0001-recent-Hunspell-fixes-for-suggestion-spelling-... ")