### PR TITLE
Fixed bugs in looping through characters and reordering to find a misspelling

### DIFF
--- a/src/hunspell/suggestmgr.cxx
+++ b/src/hunspell/suggestmgr.cxx
@@ -1096,7 +1096,7 @@ int SuggestMgr::movechar(char** wlst,
   }
 
   for (std::string::iterator p = candidate.begin() + candidate.size() - 1; p > candidate.begin(); --p) {
-    for (std::string::iterator q = p - 1; q >= candidate.begin() && std::distance(q, p) < 10; --q) {
+    for (std::string::iterator q = p - 1; q > candidate.begin() && std::distance(q, p) < 10; --q) {
       std::swap(*q, *(q + 1));
       if (std::distance(q, p) < 2)
         continue;  // omit swap char
@@ -1137,7 +1137,7 @@ int SuggestMgr::movechar_utf(char** wlst,
   }
 
   for (std::vector<w_char>::iterator p = candidate_utf.begin() + candidate_utf.size() - 1; p > candidate_utf.begin(); --p) {
-    for (std::vector<w_char>::iterator q = p - 1; q >= candidate_utf.begin() && std::distance(q, p) < 10; --q) {
+    for (std::vector<w_char>::iterator q = p - 1; q > candidate_utf.begin() && std::distance(q, p) < 10; --q) {
       std::swap(*q, *(q + 1));
       if (std::distance(q, p) < 2)
         continue;  // omit swap char


### PR DESCRIPTION
The old code produces an index-out-of-range error. It hits the beginning of the iterator and then decrements. It needs to test that it is > the beginning, not >=.