### PR TITLE
Fix for initializing empty wordchars when using UTF-8

### DIFF
--- a/src/tools/hunspell.cxx
+++ b/src/tools/hunspell.cxx
@@ -418,8 +418,8 @@ TextParser* get_parser(int format, const char* extension, Hunspell* pMS) {
   }
 #else
   if (strcmp(denc, "UTF-8") == 0) {
-    const std::vector<w_char>& vec_wordchars_utf16 = pMS->get_wordchars_utf16();
-    wordchars_utf16 = &vec_wordchars_utf16[0];
+	const std::vector<w_char>& vec_wordchars_utf16 = pMS->get_wordchars_utf16();
+	wordchars_utf16 = (vec_wordchars_utf16.size() == 0) ? NULL : &vec_wordchars_utf16[0];
     wordchars_utf16_len = vec_wordchars_utf16.size();
     io_utf8 = 1;
   } else {


### PR DESCRIPTION
When the wordchars list was empty, I hit an assertion error when it tried set the variables accordingly. It tests that the vector offset (0) < the size (0). Instead, I changed it to set the vector pointer to NULL when the list is empty.