### PR TITLE
Fix recent change to -D, which no longer outputs loaded dictionary

### DIFF
--- a/src/tools/hunspell.cxx
+++ b/src/tools/hunspell.cxx
@@ -2116,6 +2116,10 @@ int main(int argc, char** argv) {
     exit(1);
   }
 
+  if (showpath && -1 == arg_files) {
+      exit(0);
+  }
+
   /* open the private dictionaries */
   if (HOME) {
     buf.assign(HOME);


### PR DESCRIPTION
This broke Emacs’s ispell.el. Since the documentation for -D in hunspell(1)
has not changed, I presume this was unintentional.