### PR TITLE
Add support for building with CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,157 @@
+# ---------------------------------------------------------------------------- #
+cmake_minimum_required(VERSION 3.13)
+project(hunspell VERSION 1.7.0)
+
+# ~~~ Options
+option(HUNSPELL_BUILD_TOOLS       "Build Hunspell tools and parser."  ON)
+option(HUNSPELL_BUILD_STATIC_LIB  "Build static hunspell library."    ON)
+# ---------------------------------------------------------------------------- #
+
+
+# ---------------------------------------------------------------------------- #
+# ~~~ Setup paths and vars
+set(HUNSPELL_NAMESPACE             "${PROJECT_NAME}::")
+set(HUNSPELL_SRC_DIR               "${CMAKE_CURRENT_SOURCE_DIR}/src")
+set(HUNSPELL_INCLUDE_INSTALL_DIR   "include")
+set(HUNSPELL_LIBRARY_INSTALL_DIR   "lib")
+set(HUNSPELL_RUNTIME_INSTALL_DIR   "bin")
+set(HUNSPELL_INSTALL_TARGETS       ""  CACHE INTERNAL  "")
+set(HUNSPELL_EXTRA_EXPORT_TARGETS  ""  CACHE INTERNAL  "")
+set(VERSION                        ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH})
+
+# Set RPATH for installed executables
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${HUNSPELL_LIBRARY_INSTALL_DIR}")
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+# ---------------------------------------------------------------------------- #
+
+
+# ---------------------------------------------------------------------------- #
+# ~~~ Compiler options and definitions
+include(CheckCXXCompilerFlag)
+
+check_cxx_compiler_flag("-fvisibility=hidden" HAVE_VISIBILITY)
+if(NOT HAVE_VISIBILITY)
+    set(HAVE_VISIBILITY  0)
+endif()
+
+if(MSVC)
+    # Group targets in folders
+    set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
+    add_compile_definitions(
+        "_CRT_SECURE_NO_WARNINGS"
+    )
+    # Set warning level; disable specific warnings
+    add_compile_options(
+        "-W4"
+        "-wd4251"
+        "-wd4267"
+        "-wd4706"
+    )
+endif()
+# ---------------------------------------------------------------------------- #
+
+
+# ---------------------------------------------------------------------------- #
+# ~~~ Macro for adding install targets
+macro(add_install_target arg1)
+    set(HUNSPELL_INSTALL_TARGETS ${HUNSPELL_INSTALL_TARGETS} ${arg1} CACHE INTERNAL "")
+endmacro()
+
+# ~~~ Macro for adding extra export targets in build-tree
+macro(add_extra_export_target arg1)
+    set(HUNSPELL_EXTRA_EXPORT_TARGETS ${HUNSPELL_EXTRA_EXPORT_TARGETS} ${arg1} CACHE INTERNAL "")
+endmacro()
+
+# ~~~ Copy dll, don't use GENERATOR_IS_MULTI_CONFIG as it doesn't get set for some reason
+function(copy_dll_if_changed arg1 arg2)
+    set(LIB_DIR   "$<TARGET_PROPERTY:${arg1},BINARY_DIR>")
+    set(LIB_FILE  "$<TARGET_FILE_NAME:${arg1}>")
+    add_custom_command(TARGET ${arg2} POST_BUILD
+        COMMAND  ${CMAKE_COMMAND} -E copy_if_different 
+            ${LIB_DIR}/$<$<BOOL:CMAKE_CONFIGURATION_TYPES>:$<CONFIG>/>${LIB_FILE}
+            $<TARGET_FILE_DIR:${arg2}>
+    )
+endfunction()
+
+# Add source subdirectory
+add_subdirectory(src)
+# ---------------------------------------------------------------------------- #
+
+
+# ---------------------------------------------------------------------------- #
+# ~~~ Configure install and export
+include(CMakePackageConfigHelpers)
+
+# ~~~ Set paths
+set(HUNSPELL_CONFIG_INSTALL_DIR      "${HUNSPELL_LIBRARY_INSTALL_DIR}/cmake/${PROJECT_NAME}")
+set(HUNSPELL_PKG_CONFIG_INSTALL_DIR  "${HUNSPELL_LIBRARY_INSTALL_DIR}/pkgconfig")
+set(HUNSPELL_TARGETS_EXPORT_NAME     "${PROJECT_NAME}Targets")
+set(HUNSPELL_VERSION_CONFIG_FILE     "${PROJECT_NAME}ConfigVersion.cmake")
+set(HUNSPELL_PROJECT_CONFIG_FILE     "${PROJECT_NAME}Config.cmake")
+
+# ~~~ Install targets
+install(
+    TARGETS              ${HUNSPELL_INSTALL_TARGETS}
+    EXPORT               ${HUNSPELL_TARGETS_EXPORT_NAME}
+    RUNTIME DESTINATION  ${HUNSPELL_RUNTIME_INSTALL_DIR}
+    LIBRARY DESTINATION  ${HUNSPELL_LIBRARY_INSTALL_DIR}
+    ARCHIVE DESTINATION  ${HUNSPELL_LIBRARY_INSTALL_DIR}
+)
+
+# ~~~ Write config version file
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${HUNSPELL_VERSION_CONFIG_FILE}
+    COMPATIBILITY  SameMinorVersion
+)
+
+# Install project version file
+install(
+    FILES        ${CMAKE_CURRENT_BINARY_DIR}/${HUNSPELL_VERSION_CONFIG_FILE}
+    DESTINATION  ${HUNSPELL_CONFIG_INSTALL_DIR}
+)
+
+# ~~~ Generate and install project config file
+install(
+    EXPORT       ${HUNSPELL_TARGETS_EXPORT_NAME}
+    NAMESPACE    ${HUNSPELL_NAMESPACE}
+    DESTINATION  ${HUNSPELL_CONFIG_INSTALL_DIR}
+    FILE         ${HUNSPELL_PROJECT_CONFIG_FILE}
+)
+
+# Export project config file separately in build tree
+export(
+    TARGETS
+        ${HUNSPELL_INSTALL_TARGETS}
+        ${HUNSPELL_EXTRA_EXPORT_TARGETS}
+    NAMESPACE  ${HUNSPELL_NAMESPACE}
+    FILE       ${HUNSPELL_PROJECT_CONFIG_FILE}
+)
+# ---------------------------------------------------------------------------- #
+
+
+# ---------------------------------------------------------------------------- #
+# ~~~ Write pkg-config pc file
+set(PKG_PC_FILE_IN   ${CMAKE_CURRENT_BINARY_DIR}/hunspell.pc.in)
+set(PKG_PC_FILE_OUT  ${CMAKE_CURRENT_BINARY_DIR}/hunspell.pc)
+
+if (UNIX)
+    file(WRITE ${PKG_PC_FILE_IN} [=[
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@HUNSPELL_LIBRARY_INSTALL_DIR@
+includedir=${prefix}/@HUNSPELL_INCLUDE_INSTALL_DIR@
+
+Name: hunspell
+Description: Hunspell spellchecking library
+Version: @VERSION@
+Libs: -L${libdir} -l@HUNSPELL_LIB_OUTPUT_NAME@
+Cflags: -I${includedir}/@HUNSPELL_LIB_INCLUDE_PREFIX@
+]=])
+
+    configure_file(${PKG_PC_FILE_IN} ${PKG_PC_FILE_OUT} @ONLY)
+    install(
+        FILES        ${PKG_PC_FILE_OUT}
+        DESTINATION  ${HUNSPELL_PKG_CONFIG_INSTALL_DIR}
+    )
+endif()
+# ---------------------------------------------------------------------------- #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_subdirectory(hunspell)
+
+if(HUNSPELL_BUILD_TOOLS)
+    add_subdirectory(parsers)
+    add_subdirectory(tools)
+endif()

--- a/src/hunspell/CMakeLists.txt
+++ b/src/hunspell/CMakeLists.txt
@@ -1,0 +1,172 @@
+# ---------------------------------------------------------------------------- #
+# ~~~ Set target names and sources
+
+set(HUNSPELL_LIB_TARGET_PREFIX      "hunspell"                                  CACHE INTERNAL  "")
+set(HUNSPELL_LIB_TARGET_SHARED      "${HUNSPELL_LIB_TARGET_PREFIX}_lib"         CACHE INTERNAL  "")
+set(HUNSPELL_LIB_TARGET_STATIC      "${HUNSPELL_LIB_TARGET_PREFIX}_lib_static"  CACHE INTERNAL  "")
+set(HUNSPELL_LIB_TARGET_OBJ         "${HUNSPELL_LIB_TARGET_PREFIX}_lib_obj"     CACHE INTERNAL  "")
+set(HUNSPELL_LIB_INCLUDE_PREFIX     "${HUNSPELL_LIB_TARGET_PREFIX}"             CACHE INTERNAL  "")
+
+set(HUNSPELL_LIB_OUTPUT_NAME  "${HUNSPELL_LIB_TARGET_PREFIX}-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}" CACHE INTERNAL  "")
+# ---------------------------------------------------------------------------- #
+
+
+# ---------------------------------------------------------------------------- #
+# ~~~ Sources
+list(APPEND HUNSPELL_LIB_SOURCES
+    affentry.cxx
+    affixmgr.cxx
+    csutil.cxx
+    filemgr.cxx
+    hashmgr.cxx
+    hunspell.cxx
+    hunzip.cxx
+    phonet.cxx
+    replist.cxx
+    suggestmgr.cxx
+)
+
+# ~~~ Include directories
+list(APPEND HUNSPELL_LIB_INCLUDE_DIRECTORIES
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${HUNSPELL_INCLUDE_INSTALL_DIR}>
+)
+
+# ~~~ Configure header file
+configure_file(hunvisapi.h.in hunvisapi.h)
+
+# ~~~ Public headers
+list(APPEND HUNSPELL_LIB_PUBLIC_HEADERS
+    atypes.hxx
+    hunspell.h
+    hunspell.hxx
+    w_char.hxx
+    ${CMAKE_CURRENT_BINARY_DIR}/hunvisapi.h
+)
+
+# Install public headers
+install(
+    FILES        ${HUNSPELL_LIB_PUBLIC_HEADERS}
+    DESTINATION  ${HUNSPELL_INCLUDE_INSTALL_DIR}/${HUNSPELL_LIB_INCLUDE_PREFIX}
+)
+# ---------------------------------------------------------------------------- #
+
+
+# ---------------------------------------------------------------------------- #
+# ~~~ Object library shared by both shared and static targets
+add_library(${HUNSPELL_LIB_TARGET_OBJ} OBJECT)
+
+target_sources(${HUNSPELL_LIB_TARGET_OBJ}
+    PRIVATE  ${HUNSPELL_LIB_SOURCES}
+)
+target_include_directories(${HUNSPELL_LIB_TARGET_OBJ}
+    PUBLIC  ${HUNSPELL_LIB_INCLUDE_DIRECTORIES}
+)
+target_compile_definitions(${HUNSPELL_LIB_TARGET_OBJ}
+    PRIVATE  "BUILDING_LIBHUNSPELL"
+)
+
+# Shared targets have POSITION_INDEPENDENT_CODE property on by default, object
+# libraries do not, unless CMAKE_POSITION_INDEPENDENT_CODE is set to ON.
+set_target_properties(${HUNSPELL_LIB_TARGET_OBJ} PROPERTIES
+    POSITION_INDEPENDENT_CODE  ON
+    CXX_VISIBILITY_PRESET      hidden
+    FOLDER                     ${HUNSPELL_LIB_TARGET_PREFIX}
+)
+
+# Add install target
+add_install_target(${HUNSPELL_LIB_TARGET_OBJ})
+# ---------------------------------------------------------------------------- #
+
+
+# ---------------------------------------------------------------------------- #
+# ~~~ Shared library target
+add_library(${HUNSPELL_LIB_TARGET_SHARED} SHARED)
+
+target_link_libraries(${HUNSPELL_LIB_TARGET_SHARED}
+    PRIVATE
+        ${HUNSPELL_LIB_TARGET_OBJ}
+        # Cmake passes linker flags through compiler
+        $<$<CXX_COMPILER_ID:GNU>:-Wl,--no-undefined>
+        $<$<CXX_COMPILER_ID:Clang>:-Wl,-no-undefined,error>
+)
+target_include_directories(${HUNSPELL_LIB_TARGET_SHARED}
+    INTERFACE  ${HUNSPELL_LIB_INCLUDE_DIRECTORIES}
+)
+
+# Properties
+set_target_properties(${HUNSPELL_LIB_TARGET_SHARED} PROPERTIES
+    OUTPUT_NAME  ${HUNSPELL_LIB_OUTPUT_NAME}
+    VERSION      ${PROJECT_VERSION}
+    SOVERSION    ${PROJECT_VERSION_MAJOR}
+    FOLDER       ${HUNSPELL_LIB_TARGET_PREFIX}
+)
+
+# Create alias
+add_library(${HUNSPELL_NAMESPACE}${HUNSPELL_LIB_TARGET_SHARED} ALIAS ${HUNSPELL_LIB_TARGET_SHARED})
+
+# Add install target
+add_install_target(${HUNSPELL_LIB_TARGET_SHARED})
+# ---------------------------------------------------------------------------- #
+
+
+# ---------------------------------------------------------------------------- #
+# ~~~ Static library target
+option(HUNSPELL_LIB_STATIC_PIC     "Build static library with position independent code."  ON)
+option(HUNSPELL_LIB_STATIC_HIDDEN  "Set the visibility of all symbols to hidden."          OFF)
+mark_as_advanced(
+    HUNSPELL_LIB_STATIC_PIC
+    HUNSPELL_LIB_STATIC_HIDDEN
+)
+
+if(HUNSPELL_BUILD_STATIC_LIB)
+    add_library(${HUNSPELL_LIB_TARGET_STATIC} STATIC)
+    
+    # Archive the already created object files
+    target_link_libraries(${HUNSPELL_LIB_TARGET_STATIC}
+        PRIVATE  ${HUNSPELL_LIB_TARGET_OBJ}
+    )
+    target_include_directories(${HUNSPELL_LIB_TARGET_STATIC}
+        INTERFACE  ${HUNSPELL_LIB_INCLUDE_DIRECTORIES}
+    )
+    target_compile_definitions(${HUNSPELL_LIB_TARGET_STATIC}
+        INTERFACE  "HUNSPELL_STATIC"
+    )
+
+    # ~~~ Recompile source files if flags set
+    if((NOT HUNSPELL_LIB_STATIC_PIC) OR HUNSPELL_LIB_STATIC_HIDDEN)
+        set_target_properties(${HUNSPELL_LIB_TARGET_STATIC} PROPERTIES
+            SOURCES  "${HUNSPELL_LIB_SOURCES}"
+        )
+    endif()
+
+    if(NOT HUNSPELL_LIB_STATIC_PIC)
+        # Force target PIC flag to OFF in case CMAKE_POSITION_INDEPENDENT_CODE is set
+        set_target_properties(${HUNSPELL_LIB_TARGET_STATIC} PROPERTIES
+            POSITION_INDEPENDENT_CODE  OFF
+        )
+    endif()
+
+    if(HUNSPELL_LIB_STATIC_HIDDEN)
+        # Set the visibility of *all* FUNC symbols
+        set_target_properties(${HUNSPELL_LIB_TARGET_STATIC} PROPERTIES
+            CXX_VISIBILITY_PRESET  hidden
+        )
+    endif()
+
+    # ~~~ Output name and version
+    set_target_properties(${HUNSPELL_LIB_TARGET_STATIC} PROPERTIES
+        OUTPUT_NAME  ${HUNSPELL_LIB_OUTPUT_NAME}$<$<BOOL:${WIN32}>:_static>
+        VERSION      ${PROJECT_VERSION}
+        SOVERSION    ${PROJECT_VERSION_MAJOR}
+        FOLDER       ${HUNSPELL_LIB_TARGET_PREFIX}
+    )
+
+    # ~~~ Create alias
+    add_library(${HUNSPELL_NAMESPACE}${HUNSPELL_LIB_TARGET_STATIC} ALIAS ${HUNSPELL_LIB_TARGET_STATIC})
+
+    # ~~~ Add install target
+    add_install_target(${HUNSPELL_LIB_TARGET_STATIC})
+endif()
+# ---------------------------------------------------------------------------- #

--- a/src/parsers/CMakeLists.txt
+++ b/src/parsers/CMakeLists.txt
@@ -1,0 +1,72 @@
+# ---------------------------------------------------------------------------- #
+# ~~~ Set target names
+set(_LIB_OUTPUT_NAME   "parsers")
+set(_TEST_OUTPUT_NAME  "test")
+
+set(HUNSPELL_PARSERS_TARGET_PREFIX  "parsers"                                                 CACHE INTERNAL  "")
+set(HUNSPELL_PARSERS_LIB_TARGET     "${HUNSPELL_PARSERS_TARGET_PREFIX}_lib"                   CACHE INTERNAL  "")
+set(HUNSPELL_PARSERS_TEST_TARGET    "${HUNSPELL_PARSERS_TARGET_PREFIX}_${_TEST_OUTPUT_NAME}"  CACHE INTERNAL  "")
+# ---------------------------------------------------------------------------- #
+
+
+# ---------------------------------------------------------------------------- #
+# ~~~ Parsers lib target
+add_library(${HUNSPELL_PARSERS_LIB_TARGET} STATIC)
+
+target_sources(${HUNSPELL_PARSERS_LIB_TARGET}
+    PRIVATE
+        firstparser.cxx
+        htmlparser.cxx
+        latexparser.cxx
+        manparser.cxx
+        odfparser.cxx
+        textparser.cxx
+        xmlparser.cxx
+)
+target_include_directories(${HUNSPELL_PARSERS_LIB_TARGET}
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<BUILD_INTERFACE:${HUNSPELL_SRC_DIR}>
+)
+target_link_libraries(${HUNSPELL_PARSERS_LIB_TARGET}
+    PUBLIC  ${HUNSPELL_LIB_TARGET_SHARED}
+)
+set_target_properties(${HUNSPELL_PARSERS_LIB_TARGET} PROPERTIES
+    OUTPUT_NAME  ${_LIB_OUTPUT_NAME}
+    FOLDER       ${HUNSPELL_PARSERS_TARGET_PREFIX}
+)
+
+# Create an alias
+add_library(${HUNSPELL_NAMESPACE}${HUNSPELL_PARSERS_LIB_TARGET} ALIAS ${HUNSPELL_PARSERS_LIB_TARGET})
+# ---------------------------------------------------------------------------- #
+
+
+# ---------------------------------------------------------------------------- #
+# ~~~ Parsers test executable
+add_executable(${HUNSPELL_PARSERS_TEST_TARGET} testparser.cxx)
+
+target_include_directories(${HUNSPELL_PARSERS_TEST_TARGET}
+    PRIVATE  ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(${HUNSPELL_PARSERS_TEST_TARGET}
+    PRIVATE
+        ${HUNSPELL_PARSERS_LIB_TARGET}
+        ${HUNSPELL_LIB_TARGET_SHARED}
+)
+
+set_target_properties(${HUNSPELL_PARSERS_TEST_TARGET} PROPERTIES
+    OUTPUT_NAME  ${_TEST_OUTPUT_NAME}
+    FOLDER       ${HUNSPELL_PARSERS_TARGET_PREFIX}
+)
+
+if(WIN32 OR MINGW)
+    copy_dll_if_changed(${HUNSPELL_LIB_TARGET_SHARED} ${HUNSPELL_PARSERS_TEST_TARGET})
+endif()
+# ---------------------------------------------------------------------------- #
+
+
+# ---------------------------------------------------------------------------- #
+# ~~~ Add extra export targets
+add_extra_export_target(${HUNSPELL_PARSERS_LIB_TARGET})
+add_extra_export_target(${HUNSPELL_PARSERS_TEST_TARGET})
+# ---------------------------------------------------------------------------- #

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,0 +1,261 @@
+# ---------------------------------------------------------------------------- #
+# ~~~ Set target names
+set(_ANALYZE_OUTPUT_NAME   "analyze")
+set(_CHMORPH_OUTPUT_NAME   "chmorph")
+set(_EXAMPLE_OUTPUT_NAME   "example")
+set(_HUNSPELL_OUTPUT_NAME  "hunspell")
+set(_HUNZIP_OUTPUT_NAME    "hunzip")
+set(_HZIP_OUTPUT_NAME      "hzip")
+set(_MUNCH_OUTPUT_NAME     "munch")
+set(_UNMUNCH_OUTPUT_NAME   "unmunch")
+
+set(HUNSPELL_TOOLS_TARGET_PREFIX    "tools")
+set(HUNSPELL_TOOLS_ANALYZE_TARGET   "${HUNSPELL_TOOLS_TARGET_PREFIX}_${_ANALYZE_OUTPUT_NAME}")
+set(HUNSPELL_TOOLS_CHMORPH_TARGET   "${HUNSPELL_TOOLS_TARGET_PREFIX}_${_CHMORPH_OUTPUT_NAME}")
+set(HUNSPELL_TOOLS_EXAMPLE_TARGET   "${HUNSPELL_TOOLS_TARGET_PREFIX}_${_EXAMPLE_OUTPUT_NAME}")
+set(HUNSPELL_TOOLS_HUNSPELL_TARGET  "${HUNSPELL_TOOLS_TARGET_PREFIX}_${_HUNSPELL_OUTPUT_NAME}")
+set(HUNSPELL_TOOLS_HUNZIP_TARGET    "${HUNSPELL_TOOLS_TARGET_PREFIX}_${_HUNZIP_OUTPUT_NAME}")
+set(HUNSPELL_TOOLS_HZIP_TARGET      "${HUNSPELL_TOOLS_TARGET_PREFIX}_${_HZIP_OUTPUT_NAME}")
+set(HUNSPELL_TOOLS_MUNCH_TARGET     "${HUNSPELL_TOOLS_TARGET_PREFIX}_${_MUNCH_OUTPUT_NAME}")
+set(HUNSPELL_TOOLS_UNMUNCH_TARGET   "${HUNSPELL_TOOLS_TARGET_PREFIX}_${_UNMUNCH_OUTPUT_NAME}")
+
+set(HUNSPELL_TOOLS_OUTPUT_PREFIX    ""  CACHE STRING "Prefix added to binaries output filename.")
+mark_as_advanced(HUNSPELL_TOOLS_OUTPUT_PREFIX)
+# ---------------------------------------------------------------------------- #
+
+
+# ---------------------------------------------------------------------------- #
+# ~~~ Hunspell target
+
+# ~~ Add executable
+add_executable(${HUNSPELL_TOOLS_HUNSPELL_TARGET} hunspell.cxx)
+
+# ~~~ Check for headers
+include(CheckIncludeFile)
+check_include_file(locale.h     _HAVE_LOCALE_H)
+check_include_file(langinfo.h   _HAVE_LANGINFO_H)
+
+# ~~~ Find libraries  
+
+# ~ Iconv
+if(UNIX)
+    find_package(Iconv REQUIRED)
+endif()
+
+# ~ Curses
+if(UNIX)
+    option(HUNSPELL_TOOLS_USE_CURSES  "Locate and link curses library."  OFF)
+
+    if(HUNSPELL_TOOLS_USE_CURSES)
+        set(CURSES_NEED_WIDE ON)
+        find_package(Curses)
+
+        if(NOT CURSES_FOUND)
+            message(FATAL_ERROR  "Could not find curses library. Set paths manually.")
+        endif()
+    endif()
+endif()
+
+
+if(CURSES_FOUND)
+    set(_HAVE_CURSES_H    OFF)
+    set(_HAVE_NCURSESW_H  OFF)
+    set(_CURSES_INC_DIR   "")
+    set(_CURSES_LIB       "")
+
+    get_filename_component(_CURSES_LIB_NAME  ${CURSES_NCURSES_LIBRARY}  NAME)
+
+    # libcurses just points to libncurses in most cases
+    if(EXISTS "${CURSES_INCLUDE_PATH}/curses.h")
+        set(_HAVE_CURSES_H   ON)
+        set(_CURSES_INC_DIR  "${CURSES_INCLUDE_PATH}")
+        set(_CURSES_LIB      "${CURSES_CURSES_LIBRARY}")
+    endif()
+    if(EXISTS "${CURSES_INCLUDE_PATH}/ncurses/curses.h")
+        set(_HAVE_CURSES_H   ON)
+        set(_CURSES_INC_DIR  "${CURSES_INCLUDE_PATH}/ncurses")
+        set(_CURSES_LIB      "${CURSES_NCURSES_LIBRARY}")
+    endif()
+    if(EXISTS "${CURSES_INCLUDE_PATH}/ncursesw/curses.h" AND ${_CURSES_LIB_NAME} MATCHES "w")
+        set(_HAVE_NCURSESW_H  ON)
+        set(_CURSES_INC_DIR   "${CURSES_INCLUDE_PATH}")
+        set(_CURSES_LIB       "${CURSES_NCURSES_LIBRARY}")
+    endif()
+endif()
+
+# ~ Readline
+if(UNIX)
+    option(HUNSPELL_TOOLS_USE_READLINE  "Locate and link readline library."  OFF)
+endif()
+
+if(HUNSPELL_TOOLS_USE_READLINE)
+    find_path(READLINE_INCLUDE_PATH
+        NAMES  readline/readline.h
+        DOC    "Readline include directory."
+    )
+    find_library(READLINE_LIBRARY
+        NAMES  readline
+        DOC    "Readline library."
+    )
+    mark_as_advanced(
+        READLINE_INCLUDE_PATH
+        READLINE_LIBRARY
+    )
+    find_package_handle_standard_args(Readline
+        REQUIRED_VARS  
+            READLINE_LIBRARY
+            READLINE_INCLUDE_PATH
+    )
+    if(NOT Readline_FOUND)
+        message(ERROR  "Could not find readline library. Set paths manually.")
+    endif()
+endif()
+
+# ~~~ Define VERSION in a dummy config.h header file, other defs are added 
+#     through target_compile_definitions()
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/config.h.in [=[#define VERSION "@VERSION@"]=])
+configure_file(${CMAKE_CURRENT_BINARY_DIR}/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h @ONLY)
+
+# ~~~ Update target
+target_compile_definitions(${HUNSPELL_TOOLS_HUNSPELL_TARGET}
+    PRIVATE
+        $<$<BOOL:${_HAVE_LOCALE_H}>:HAVE_LOCALE_H>
+        $<$<BOOL:${_HAVE_LANGINFO_H}>:HAVE_LANGINFO_H>
+        $<$<BOOL:${Iconv_FOUND}>:HAVE_ICONV>
+        $<$<BOOL:${Iconv_FOUND}>:ICONV_CONST=>
+        $<$<BOOL:${_HAVE_CURSES_H}>:HAVE_CURSES_H>
+        $<$<BOOL:${_HAVE_NCURSESW_H}>:HAVE_NCURSESW_CURSES_H>
+        $<$<BOOL:${Readline_FOUND}>:HAVE_READLINE>
+)
+target_include_directories(${HUNSPELL_TOOLS_HUNSPELL_TARGET}
+    PRIVATE
+        ${CMAKE_CURRENT_BINARY_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        $<$<BOOL:${_CURSES_INC_DIR}>:${_CURSES_INC_DIR}>
+        $<$<BOOL:${Readline_FOUND}>:${READLINE_INCLUDE_PATH}>
+)
+target_link_libraries(${HUNSPELL_TOOLS_HUNSPELL_TARGET}
+    PRIVATE
+        ${HUNSPELL_PARSERS_LIB_TARGET}
+        $<$<BOOL:${Iconv_FOUND}>:Iconv::Iconv>
+        $<$<BOOL:${_CURSES_LIB}>:${_CURSES_LIB}>
+        $<$<BOOL:${Readline_FOUND}>:${READLINE_LIBRARY}>
+)
+
+set_target_properties(${HUNSPELL_TOOLS_HUNSPELL_TARGET} PROPERTIES
+    OUTPUT_NAME  ${HUNSPELL_TOOLS_OUTPUT_PREFIX}${_HUNSPELL_OUTPUT_NAME}
+    FOLDER       ${HUNSPELL_TOOLS_TARGET_PREFIX}
+)
+# ---------------------------------------------------------------------------- #
+
+
+# ---------------------------------------------------------------------------- #
+# ~~~ Analyze
+add_executable(${HUNSPELL_TOOLS_ANALYZE_TARGET} analyze.cxx)
+
+target_link_libraries(${HUNSPELL_TOOLS_ANALYZE_TARGET}
+    PRIVATE  ${HUNSPELL_LIB_TARGET_SHARED}
+)
+set_target_properties(${HUNSPELL_TOOLS_ANALYZE_TARGET} PROPERTIES
+    OUTPUT_NAME  ${HUNSPELL_TOOLS_OUTPUT_PREFIX}${_ANALYZE_OUTPUT_NAME}
+    FOLDER       ${HUNSPELL_TOOLS_TARGET_PREFIX}
+)
+
+# ~~~ Chmorph target
+add_executable(${HUNSPELL_TOOLS_CHMORPH_TARGET} chmorph.cxx)
+
+target_link_libraries(${HUNSPELL_TOOLS_CHMORPH_TARGET}
+    PRIVATE  ${HUNSPELL_PARSERS_LIB_TARGET}
+)
+set_target_properties(${HUNSPELL_TOOLS_CHMORPH_TARGET} PROPERTIES
+    OUTPUT_NAME  ${HUNSPELL_TOOLS_OUTPUT_PREFIX}${_CHMORPH_OUTPUT_NAME}
+    FOLDER       ${HUNSPELL_TOOLS_TARGET_PREFIX}
+)
+
+# ~~~ Example target
+add_executable(${HUNSPELL_TOOLS_EXAMPLE_TARGET} example.cxx)
+
+target_link_libraries(${HUNSPELL_TOOLS_EXAMPLE_TARGET}
+    PRIVATE  ${HUNSPELL_LIB_TARGET_SHARED}
+)
+set_target_properties(${HUNSPELL_TOOLS_EXAMPLE_TARGET} PROPERTIES
+    OUTPUT_NAME  ${HUNSPELL_TOOLS_OUTPUT_PREFIX}${_EXAMPLE_OUTPUT_NAME}
+    FOLDER       ${HUNSPELL_TOOLS_TARGET_PREFIX}
+)
+
+# ~~~ Hunzip target
+add_executable(${HUNSPELL_TOOLS_HUNZIP_TARGET} hunzip.cxx)
+
+target_link_libraries(${HUNSPELL_TOOLS_HUNZIP_TARGET}
+    PRIVATE  ${HUNSPELL_LIB_TARGET_SHARED}
+)
+set_target_properties(${HUNSPELL_TOOLS_HUNZIP_TARGET} PROPERTIES
+    OUTPUT_NAME  ${HUNSPELL_TOOLS_OUTPUT_PREFIX}${_HUNZIP_OUTPUT_NAME}
+    FOLDER       ${HUNSPELL_TOOLS_TARGET_PREFIX}
+)
+
+if((NOT WIN32) OR MINGW)
+    # ~~~ Hzip target
+    add_executable(${HUNSPELL_TOOLS_HZIP_TARGET} hzip.cxx)
+
+    set_target_properties(${HUNSPELL_TOOLS_HZIP_TARGET} PROPERTIES
+        OUTPUT_NAME  ${HUNSPELL_TOOLS_OUTPUT_PREFIX}${_HZIP_OUTPUT_NAME}
+        FOLDER       ${HUNSPELL_TOOLS_TARGET_PREFIX}
+    )
+
+    # ~~~ Munch target
+    add_executable(${HUNSPELL_TOOLS_MUNCH_TARGET} munch.cxx)
+
+    target_include_directories(${HUNSPELL_TOOLS_MUNCH_TARGET}
+        PRIVATE  ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    set_target_properties(${HUNSPELL_TOOLS_MUNCH_TARGET} PROPERTIES
+        OUTPUT_NAME  ${HUNSPELL_TOOLS_OUTPUT_PREFIX}${_MUNCH_OUTPUT_NAME}
+        FOLDER       ${HUNSPELL_TOOLS_TARGET_PREFIX}
+    )
+
+    # ~~~ Unmunch target
+    add_executable(${HUNSPELL_TOOLS_UNMUNCH_TARGET} unmunch.cxx)
+
+    target_include_directories(${HUNSPELL_TOOLS_UNMUNCH_TARGET}
+        PRIVATE  ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    set_target_properties(${HUNSPELL_TOOLS_UNMUNCH_TARGET} PROPERTIES
+        OUTPUT_NAME  ${HUNSPELL_TOOLS_OUTPUT_PREFIX}${_UNMUNCH_OUTPUT_NAME}
+        FOLDER       ${HUNSPELL_TOOLS_TARGET_PREFIX}
+    )
+endif()
+# ---------------------------------------------------------------------------- #
+
+
+# ---------------------------------------------------------------------------- #
+# ~~~ Copy dll to binary dir
+if(WIN32 OR MINGW)
+    # In case targets are built separately
+    copy_dll_if_changed(${HUNSPELL_LIB_TARGET_SHARED} ${HUNSPELL_TOOLS_ANALYZE_TARGET})
+    copy_dll_if_changed(${HUNSPELL_LIB_TARGET_SHARED} ${HUNSPELL_TOOLS_CHMORPH_TARGET})
+    copy_dll_if_changed(${HUNSPELL_LIB_TARGET_SHARED} ${HUNSPELL_TOOLS_EXAMPLE_TARGET})
+    copy_dll_if_changed(${HUNSPELL_LIB_TARGET_SHARED} ${HUNSPELL_TOOLS_HUNSPELL_TARGET})
+    copy_dll_if_changed(${HUNSPELL_LIB_TARGET_SHARED} ${HUNSPELL_TOOLS_HUNZIP_TARGET})
+    if(MINGW)
+        copy_dll_if_changed(${HUNSPELL_LIB_TARGET_SHARED} ${HUNSPELL_TOOLS_HZIP_TARGET})
+        copy_dll_if_changed(${HUNSPELL_LIB_TARGET_SHARED} ${HUNSPELL_TOOLS_MUNCH_TARGET})
+        copy_dll_if_changed(${HUNSPELL_LIB_TARGET_SHARED} ${HUNSPELL_TOOLS_UNMUNCH_TARGET})
+    endif()
+endif()
+# ---------------------------------------------------------------------------- #
+
+
+# ---------------------------------------------------------------------------- #
+# ~~~ Add install targets
+add_install_target(${HUNSPELL_TOOLS_ANALYZE_TARGET})
+add_install_target(${HUNSPELL_TOOLS_CHMORPH_TARGET})
+add_install_target(${HUNSPELL_TOOLS_HUNSPELL_TARGET})
+add_install_target(${HUNSPELL_TOOLS_HUNZIP_TARGET})
+
+if((NOT WIN32) OR MINGW)
+    add_install_target(${HUNSPELL_TOOLS_HZIP_TARGET})
+    add_install_target(${HUNSPELL_TOOLS_MUNCH_TARGET})
+    add_install_target(${HUNSPELL_TOOLS_UNMUNCH_TARGET})
+endif()
+# ---------------------------------------------------------------------------- #

--- a/src/tools/hunspell.cxx
+++ b/src/tools/hunspell.cxx
@@ -579,7 +579,7 @@ const char* basename(const char* s, char c) {
 }
 
 #ifdef HAVE_CURSES_H
-char* scanline(char* message) {
+char* scanline(const char* message) {
   char input[INPUTLEN];
   printw(message);
   echo();


### PR DESCRIPTION
Tested to work on Windows, Linux and macOS. 

The following options `HUNSPELL_BUILD_TOOLS` and `HUNSPELL_BUILD_STATIC` are provided to selectively build the hunspell tools (including parsers), as well as the static version of libhunspell, respectively. `HUNSPELL_TOOLS_OUTPUT_PREFIX` can be used to add a prefix to the built executables output name, resolving the name conflict issue mentioned in PR #605.

The latest Visual Studio generators can be used to generate a multi-config solution on Windows. This renderes the project files already present in source tree under `msvc/` as unnecessary.

The `po/` and `test/` directories are not included in the current script, though it can be extended to also process `po` files, as CMake provides modules for handling `gettext`.

There is an issue when building hunspell on Mac, where ncurses cannot be found even when installed correctly using homebrew. This is because the CMake package `FindCurses` used to find ncurses fails to find the required libraries and paths. Everything works OK when paths are set manually during configuration. Also worth noting that the latest readline package in homebrew is not compatible with the current code that uses it, due to missing identifiers: `rl_delete_text()`, `rl_done`, `rl_set_key()`. Haven't tried with previous versions of the readline library.

The `hunspell.cxx` tool source file was slightly modified to keep the Clang compiler on Apple happy.