### PR TITLE
Add "-DHUNSPELL_STATIC" to hunspell.pc if hunspell is built statically

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,11 +10,13 @@ AC_USE_SYSTEM_EXTENSIONS
 AC_CONFIG_MACRO_DIRS([m4])
 AM_INIT_AUTOMAKE
 
-# the following 4 lines are used for pkg-check's .pc.in file
+# the following 6 lines are used for pkg-check's .pc.in file
 HUNSPELL_VERSION_MAJOR=`echo $VERSION | cut -d"." -f1`
 HUNSPELL_VERSION_MINOR=`echo $VERSION | cut -d"." -f2`
+AS_IF([test "x$enable_static" = xyes], [PC_CFLAGS=-DHUNSPELL_STATIC])
 AC_SUBST(HUNSPELL_VERSION_MAJOR)
 AC_SUBST(HUNSPELL_VERSION_MINOR)
+AC_SUBST(PC_CFLAGS)
 
 # Checks for programs.
 AC_PROG_CXX

--- a/hunspell.pc.in
+++ b/hunspell.pc.in
@@ -7,4 +7,4 @@ Name: hunspell
 Description: Hunspell spellchecking library
 Version: @VERSION@
 Libs: -L${libdir} -lhunspell-@HUNSPELL_VERSION_MAJOR@.@HUNSPELL_VERSION_MINOR@
-Cflags: -I${includedir}/hunspell
+Cflags: -I${includedir}/hunspell @PC_CFLAGS@


### PR DESCRIPTION
src/hunspell/hunvisapi.h (which is installed as part of the hunspell API) checks this definition.
When linking a program statically to hunspell (at least on Windows) thus requires HUNSPELL_STATIC to be defined. One easy way to achieve this is to include it in the pkg-config file. See also the discussion at https://github.com/mxe/mxe/pull/2290 (Note that according to https://people.freedesktop.org/~dbn/pkg-config-guide.html, "there is not a private variant of Cflags")