### PR TITLE
latex parser: add support for cleveref style referencing

### DIFF
--- a/src/parsers/latexparser.cxx
+++ b/src/parsers/latexparser.cxx
@@ -122,6 +122,8 @@ static struct {
                {{"\\psfig", NULL}, 1},
                {{"\\url", NULL}, 1},
                {{"\\eqref", NULL}, 1},
+               {{"\\cref", NULL}, 1},
+               {{"\\Cref", NULL}, 1},
                {{"\\vskip", NULL}, 1},
                {{"\\vglue", NULL}, 1},
                {{"\'\'", NULL}, 1}};


### PR DESCRIPTION
Cleveref uses the commands \Cref, \cref, \Cref* and \cref* to
reference labels. This should not lead to a spelling error.

Example LaTeX code:

    \documentclass{article}
    
    \usepackage{hyperref}
    \usepackage{cleveref}
    
    \begin{document}
    
    \begin{equation}
      \label{eq:badlyspeltword}
      3 = 2 + 1
    \end{equation}
    
    \Cref{eq:badlyspeltword}, or \cref{eq:badlyspeltword}, or \cref*{eq:badlyspeltword}
    
    % also in comments \cref{eq:badlyspeltword}
    
    \end{document}
