### PR TITLE
Make hunspell look in XDG_DATA_DIRS for dictionaries

### DIFF
--- a/src/tools/hunspell.cxx
+++ b/src/tools/hunspell.cxx
@@ -2044,6 +2044,13 @@ int main(int argc, char** argv) {
     if (getenv("DICPATH")) {
       path_std_str.append(getenv("DICPATH")).append(PATHSEP);
     }
+    if (getenv("XDG_DATA_DIRS")) {
+      char* dir = strtok(getenv("XDG_DATA_DIRS"), ":");
+      while (dir != NULL) {
+        path_std_str.append(dir).append("/hunspell:");
+        dir = strtok(NULL, ":");
+      }
+    }
     path_std_str.append(LIBDIR).append(PATHSEP);
     if (HOME) {
       const char * userooodir[] = USEROOODIR;


### PR DESCRIPTION
Some dictionaries may exist but only show up under XDG_DATA_DIRS. For
instance, $HOME/.local/share/hunspell could contain some dictionaries.

This patch adds each directory in the hunspell subdir of each
XDG_DATA_DIRS to the lookup path.