### PR TITLE
man: fix empty escaped syntax

### DIFF
--- a/man/hunspell.5
+++ b/man/hunspell.5
@@ -16,7 +16,8 @@ contains the approximate word count (for optimal hash memory size). Each word
 may optionally be followed by a slash ("/") and one or more flags, which
 represents the word attributes, for example affixes.
 
-Note: Dictionary words can contain also slashes when escaped like  "\/" syntax. 
+Note: Dictionary words can contain also slashes when escaped like "\\/"
+syntax.
 
 It's worth to add not only words, but word pairs to the dictionary to get correct
 suggestions for common misspellings with missing space, as in the


### PR DESCRIPTION
Previously, the generated man page for escaped syntax would be rendered
as,

	... when escaped like "" syntax.

The correct text should be rendered as,

	... when escaped like "\/" syntax.