### PR TITLE
Adding -I command line argument to ignore file extensions.

### DIFF
--- a/man/hunspell.1
+++ b/man/hunspell.1
@@ -289,6 +289,9 @@ The input file is in SGML/HTML format.
 .IP \fB\-h,\ \-\-help\fR
 Short help.
 
+.IP \fB\-I\fR
+Ignore file extensions
+
 .IP \fB\-i\ enc\fR
 Set input encoding.
 

--- a/src/tools/hunspell.cxx
+++ b/src/tools/hunspell.cxx
@@ -219,6 +219,7 @@ int showpath = 0;   // show detected path of the dictionary
 int checkurl = 0;   // check URLs and mail addresses
 int checkapos = 0;  // force typographic apostrophe
 int warn = 0;  // warn potential mistakes (dictionary words with WARN flags)
+int ignore_file_exts = 0;  // ignore file extensions
 const char* ui_enc = NULL;  // locale character encoding (default for I/O)
 const char* io_enc = NULL;  // I/O character encoding
 
@@ -444,7 +445,7 @@ TextParser* get_parser(int format, const char* extension, Hunspell* pMS) {
     }
   }
 
-  if ((!p) && (extension)) {
+  if ((!p) && (extension) && (!ignore_file_exts)) {
     if ((strcmp(extension, "html") == 0) || (strcmp(extension, "htm") == 0) ||
         (strcmp(extension, "xhtml") == 0)) {
       if (io_utf8) {
@@ -1983,6 +1984,8 @@ int main(int argc, char** argv) {
       warn = 1;
     } else if ((strcmp(argv[i], "--check-url") == 0)) {
       checkurl = 1;
+    } else if ((strcmp(argv[i], "-I") == 0)) {
+      ignore_file_exts = 1;
     } else if ((strcmp(argv[i], "--check-apostrophe") == 0)) {
       checkapos = 1;
     } else if ((arg_files == -1) &&


### PR DESCRIPTION
I use hunspell to spell check source code with a Bash function like this:
```
function spell
{
    hunspell -l $* | sort | uniq | less
}
```
`sort` and `uniq` consolidates all the false keyword positives and I can just page through the output with `less` and scan with my eye for misspelled words. I recently tried to do this with an XML file, to no avail. `hunspell` will pay attention to XML tags if the file has a .xml extension, or if a file doesn't, you can use the `-X` flag to force it to consider the XML tags. What is lacking is a way to tell `hunspell` to spell check a`.xml` file as a regular file (i.e. ignore the `.xml` file extension.) unless you temporarily remove the file extension.

I'm proposing adding an ignore file extensions flag `-I` to have `hunspell` ignore any special behavior related to file extensions. 

(Before ignore flag)
```
$ cat test.xml
<?xml version="1.0" encoding="utf-8"?>
This getss spell checked currently.
<!-- This doess not get checked, but I want it checked. -->
 
$/usr/bin/hunspell -l test.xml | sort | uniq
getss
```
(After ignore flag implemented)
```
$ /home/dnygren/hunspell_dan/src/tools/hunspell -l -I * | sort | uniq
doess
getss
utf
xml
```
Thank you for your consideration.

Dan Nygren
dan.nygren@gmail.com