### PR TITLE
Fix AppVeyor and Travis checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,10 @@ os:
   - osx
 
 before_install:
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+        brew --version;
+        HOMEBREW_NO_ENV_FILTERING=1 brew update;
+    fi
 
 install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 #  - BASH_PATH: c:\cygwin\bin\bash
 
 install:
-- cmd: '%BASH_PATH% -lc "pacman --noconfirm -S mingw-w64-x86_64-boost"'
+- cmd: '%BASH_PATH% -lc "pacman --noconfirm -Syu mingw-w64-x86_64-boost"'
 
 build_script:
 - cmd: '%BASH_PATH% -lc "cd $APPVEYOR_BUILD_FOLDER; autoreconf -i && ./configure && make && make check"'


### PR DESCRIPTION
Travis shows "No output has been received in the last 10m0s" after a "Homebrew is run entirely by unpaid volunteers. Please consider donating: <link>". Found this workaround in https://github.com/Linuxbrew/brew/issues/820 -- brew version could be out-of-date, reason why I also added a `brew --version` to print its version before other commands.