### PR TITLE
Add ppc64le support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ os:
   - linux
   - osx
 
+arch:
+  - amd64
+  - ppc64le
+
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
         brew --version;


### PR DESCRIPTION
Hi,
I had added ppc64le support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/hunspell/builds/179537691
Please have a look.

Thanks!!"