### PR TITLE
Add const to scanline signature in tools/hunspell.cxx to resolve clang compile issue

### DIFF
--- a/src/tools/hunspell.cxx
+++ b/src/tools/hunspell.cxx
@@ -579,7 +579,7 @@ const char* basename(const char* s, char c) {
 }
 
 #ifdef HAVE_CURSES_H
-char* scanline(char* message) {
+char* scanline(const char* message) {
   char input[INPUTLEN];
   printw(message);
   echo();


### PR DESCRIPTION
Fix for issue https://github.com/hunspell/hunspell/issues/705 
