### PR TITLE
use logical operations for bit masks instead of +-

### DIFF
--- a/src/hunspell/affixmgr.cxx
+++ b/src/hunspell/affixmgr.cxx
@@ -1052,7 +1052,7 @@ int AffixMgr::encodeit(AffEntry& entry, const char* cs) {
     } else if (cs[MAXCONDLEN]) {
       //there is more conditions than fit in fixed space, so its
       //a long condition
-      entry.opts += aeLONGCOND;
+      entry.opts |= aeLONGCOND;
       entry.c.l.conds2 = mystrdup(cs + MAXCONDLEN_1);
       if (!entry.c.l.conds2)
         return 1;
@@ -4492,11 +4492,11 @@ bool AffixMgr::parse_affix(const std::string& line,
 
         char opts = ff;
         if (utf8)
-          opts += aeUTF8;
+          opts |= aeUTF8;
         if (pHMgr->is_aliasf())
-          opts += aeALIASF;
+          opts |= aeALIASF;
         if (pHMgr->is_aliasm())
-          opts += aeALIASM;
+          opts |= aeALIASM;
         affentries.initialize(numents, opts, aflag);
       }
 

--- a/src/hunspell/hashmgr.cxx
+++ b/src/hunspell/hashmgr.cxx
@@ -249,15 +249,15 @@ int HashMgr::add_word(const std::string& in_word,
 
   // store the description string or its pointer
   if (desc) {
-    hp->var += H_OPT;
+    hp->var |= H_OPT;
     if (aliasm) {
-      hp->var += H_OPT_ALIASM;
+      hp->var |= H_OPT_ALIASM;
       store_pointer(hpw + word->size() + 1, get_aliasm(atoi(desc->c_str())));
     } else {
       strcpy(hpw + word->size() + 1, desc->c_str());
     }
     if (strstr(HENTRY_DATA(hp), MORPH_PHON)) {
-      hp->var += H_OPT_PHON;
+      hp->var |= H_OPT_PHON;
       // store ph: fields (pronounciation, misspellings, old orthography etc.)
       // of a morphological description in reptable to use in REP replacements.
       if (reptable.capacity() < (unsigned int)(tablesize/MORPH_PHON_RATIO))

--- a/src/hunspell/hunspell.cxx
+++ b/src/hunspell/hunspell.cxx
@@ -521,7 +521,7 @@ bool HunspellImpl::spell_internal(const std::string& word, int* info, std::strin
     case HUHCAP:
     /* FALLTHROUGH */
     case HUHINITCAP:
-      *info += SPELL_ORIGCAP;
+      *info |= SPELL_ORIGCAP;
     /* FALLTHROUGH */
     case NOCAP:
       rv = checkword(scw, info, root);
@@ -532,7 +532,7 @@ bool HunspellImpl::spell_internal(const std::string& word, int* info, std::strin
       }
       break;
     case ALLCAP: {
-      *info += SPELL_ORIGCAP;
+      *info |= SPELL_ORIGCAP;
       rv = checkword(scw, info, root);
       if (rv)
         break;
@@ -603,7 +603,7 @@ bool HunspellImpl::spell_internal(const std::string& word, int* info, std::strin
     case INITCAP: {
       // handle special capitalization of dotted I
       bool Idot = (utf8 && (unsigned char) scw[0] == 0xc4 && (unsigned char) scw[1] == 0xb0);
-      *info += SPELL_ORIGCAP;
+      *info |= SPELL_ORIGCAP;
       if (captype == ALLCAP) {
           mkallsmall2(scw, sunicw);
           mkinitcap2(scw, sunicw);
@@ -611,10 +611,10 @@ bool HunspellImpl::spell_internal(const std::string& word, int* info, std::strin
              scw.replace(0, 1, "\xc4\xb0");
       }
       if (captype == INITCAP)
-        *info += SPELL_INITCAP;
+        *info |= SPELL_INITCAP;
       rv = checkword(scw, info, root);
       if (captype == INITCAP)
-        *info -= SPELL_INITCAP;
+        *info &= ~SPELL_INITCAP;
       // forbid bad capitalization
       // (for example, ijs -> Ijs instead of IJs in Dutch)
       // use explicit forms in dic: Ijs/F (F = FORBIDDENWORD flag)
@@ -639,10 +639,10 @@ bool HunspellImpl::spell_internal(const std::string& word, int* info, std::strin
           u8buffer = scw;
           u8buffer.push_back('.');
           if (captype == INITCAP)
-            *info += SPELL_INITCAP;
+            *info |= SPELL_INITCAP;
           rv = checkword(u8buffer, info, root);
           if (captype == INITCAP)
-            *info -= SPELL_INITCAP;
+            *info &= ~SPELL_INITCAP;
           if (rv && is_keepcase(rv) && (captype == ALLCAP))
             rv = NULL;
           break;
@@ -663,7 +663,7 @@ bool HunspellImpl::spell_internal(const std::string& word, int* info, std::strin
   if (rv) {
     if (pAMgr && pAMgr->get_warn() && rv->astr &&
         TESTAFF(rv->astr, pAMgr->get_warn(), rv->alen)) {
-      *info += SPELL_WARN;
+      *info |= SPELL_WARN;
       if (pAMgr->get_forbidwarn())
         return false;
       return true;
@@ -802,13 +802,13 @@ struct hentry* HunspellImpl::checkword(const std::string& w, int* info, std::str
     if ((he) && (he->astr) && (pAMgr) &&
         TESTAFF(he->astr, pAMgr->get_forbiddenword(), he->alen)) {
       if (info)
-        *info += SPELL_FORBIDDEN;
+        *info |= SPELL_FORBIDDEN;
       // LANG_hu section: set dash information for suggestions
       if (langnum == LANG_hu) {
         if (pAMgr->get_compoundflag() &&
             TESTAFF(he->astr, pAMgr->get_compoundflag(), he->alen)) {
           if (info)
-            *info += SPELL_COMPOUND;
+            *info |= SPELL_COMPOUND;
         }
       }
       return NULL;
@@ -843,7 +843,7 @@ struct hentry* HunspellImpl::checkword(const std::string& w, int* info, std::str
       if ((he->astr) && (pAMgr) &&
           TESTAFF(he->astr, pAMgr->get_forbiddenword(), he->alen)) {
         if (info)
-          *info += SPELL_FORBIDDEN;
+          *info |= SPELL_FORBIDDEN;
         return NULL;
       }
       if (root) {
@@ -876,7 +876,7 @@ struct hentry* HunspellImpl::checkword(const std::string& w, int* info, std::str
           }
         }
         if (info)
-          *info += SPELL_COMPOUND;
+          *info |= SPELL_COMPOUND;
       }
     }
   }

--- a/tests/forbiddenword.dic
+++ b/tests/forbiddenword.dic
@@ -6,3 +6,8 @@ foo/S	[4]
 bar/YS	[5]
 bars/X
 foos/X
+kg
+Kg/X
+KG/X
+cm
+Cm/X

--- a/tests/forbiddenword.good
+++ b/tests/forbiddenword.good
@@ -1,3 +1,4 @@
 foo
 bar
-
+kg
+cm

--- a/tests/forbiddenword.wrong
+++ b/tests/forbiddenword.wrong
@@ -2,3 +2,6 @@ bars
 foos
 foobar
 barfoo
+Kg
+KG
+Cm


### PR DESCRIPTION
The trouble with + is that it's not idempotent, and several places can add the same mask twice, resulting in a different bitmask. This caused a bug with incorrectly accepted uppercase words explicitly marked as forbidden in the dictionary.