### PR TITLE
remove ambiguities from tests/forbiddenword.dic

### DIFF
--- a/tests/forbiddenword.dic
+++ b/tests/forbiddenword.dic
@@ -1,8 +1,6 @@
 5
-foo/S	[1]
-foo/YX	[2]
-foo/Y	[3]
-foo/S	[4]
-bar/YS	[5]
+foo/S
+foo/YX
+bar/YS
 bars/X
 foos/X


### PR DESCRIPTION
It's not clear what's meant by having so many entries for `foo`, two of them identical and others ambiguous. Swapping the two Y-flagged entries made the test fail, while the documentation implies no dependency on dictionary order. The behavior may remain undefined in such cases, but let's at least not depend on it in tests.