### PR TITLE
correction of a knowingly false condition.

### DIFF
--- a/src/hunspell/affixmgr.cxx
+++ b/src/hunspell/affixmgr.cxx
@@ -2274,8 +2274,6 @@ int AffixMgr::compound_check_morph(const char* word,
         rv = rv->next_homonym;
       }
 
-      if (timelimit == 0)
-        return 0;
 
       if (rv)
         affixed = 0;


### PR DESCRIPTION
this if is not achievable because if the condition is true, then it is implemented above with the exit from the function.
I suggest a simple fix.