### PR TITLE
use AM_GNU_GETTEXT_VERSION instead of AM_GNU_GETTEXT_REQUIRE_VERSION

### DIFF
--- a/ABOUT-NLS
+++ b/ABOUT-NLS
@@ -1,16 +1,16 @@
 1 Notes on the Free Translation Project
 ***************************************
 
-Free software is going international!  The Free Translation Project is a
-way to get maintainers of free software, translators, and users all
+Free software is going international!  The Free Translation Project is
+a way to get maintainers of free software, translators, and users all
 together, so that free software will gradually become able to speak many
 languages.  A few packages already provide translations for their
 messages.
 
-   If you found this 'ABOUT-NLS' file inside a distribution, you may
-assume that the distributed package does use GNU 'gettext' internally,
+   If you found this `ABOUT-NLS' file inside a distribution, you may
+assume that the distributed package does use GNU `gettext' internally,
 itself available at your nearest GNU archive site.  But you do _not_
-need to install GNU 'gettext' prior to configuring, installing or using
+need to install GNU `gettext' prior to configuring, installing or using
 this package with messages translated.
 
    Installers will find here some useful hints.  These notes also
@@ -18,91 +18,137 @@ explain how users should proceed for getting the programs to use the
 available translations.  They tell how people wanting to contribute and
 work on translations can contact the appropriate team.
 
-1.1 INSTALL Matters
+   When reporting bugs in the `intl/' directory or bugs which may be
+related to internationalization, you should tell about the version of
+`gettext' which is used.  The information can be found in the
+`intl/VERSION' file, in internationalized packages.
+
+1.1 Quick configuration advice
+==============================
+
+If you want to exploit the full power of internationalization, you
+should configure it using
+
+     ./configure --with-included-gettext
+
+to force usage of internationalizing routines provided within this
+package, despite the existence of internationalizing capabilities in the
+operating system where this package is being installed.  So far, only
+the `gettext' implementation in the GNU C library version 2 provides as
+many features (such as locale alias, message inheritance, automatic
+charset conversion or plural form handling) as the implementation here.
+It is also not possible to offer this additional functionality on top
+of a `catgets' implementation.  Future versions of GNU `gettext' will
+very likely convey even more functionality.  So it might be a good idea
+to change to GNU `gettext' as soon as possible.
+
+   So you need _not_ provide this option if you are using GNU libc 2 or
+you have installed a recent copy of the GNU gettext package with the
+included `libintl'.
+
+1.2 INSTALL Matters
 ===================
 
 Some packages are "localizable" when properly installed; the programs
 they contain can be made to speak your own native language.  Most such
-packages use GNU 'gettext'.  Other packages have their own ways to
-internationalization, predating GNU 'gettext'.
+packages use GNU `gettext'.  Other packages have their own ways to
+internationalization, predating GNU `gettext'.
 
    By default, this package will be installed to allow translation of
 messages.  It will automatically detect whether the system already
-provides the GNU 'gettext' functions.  Installers may use special
-options at configuration time for changing the default behaviour.  The
-command:
+provides the GNU `gettext' functions.  If not, the included GNU
+`gettext' library will be used.  This library is wholly contained
+within this package, usually in the `intl/' subdirectory, so prior
+installation of the GNU `gettext' package is _not_ required.
+Installers may use special options at configuration time for changing
+the default behaviour.  The commands:
 
+     ./configure --with-included-gettext
      ./configure --disable-nls
 
-will _totally_ disable translation of messages.
+will, respectively, bypass any pre-existing `gettext' to use the
+internationalizing routines provided within this package, or else,
+_totally_ disable translation of messages.
 
-   When you already have GNU 'gettext' installed on your system and run
-configure without an option for your new package, 'configure' will
-probably detect the previously built and installed 'libintl' library and
-will decide to use it.  If not, you may have to to use the
-'--with-libintl-prefix' option to tell 'configure' where to look for it.
+   When you already have GNU `gettext' installed on your system and run
+configure without an option for your new package, `configure' will
+probably detect the previously built and installed `libintl.a' file and
+will decide to use this.  This might not be desirable.  You should use
+the more recent version of the GNU `gettext' library.  I.e. if the file
+`intl/VERSION' shows that the library which comes with this package is
+more recent, you should use
 
-   Internationalized packages usually have many 'po/LL.po' files, where
+     ./configure --with-included-gettext
+
+to prevent auto-detection.
+
+   The configuration process will not test for the `catgets' function
+and therefore it will not be used.  The reason is that even an
+emulation of `gettext' on top of `catgets' could not provide all the
+extensions of the GNU `gettext' library.
+
+   Internationalized packages usually have many `po/LL.po' files, where
 LL gives an ISO 639 two-letter code identifying the language.  Unless
-translations have been forbidden at 'configure' time by using the
-'--disable-nls' switch, all available translations are installed
-together with the package.  However, the environment variable 'LINGUAS'
+translations have been forbidden at `configure' time by using the
+`--disable-nls' switch, all available translations are installed
+together with the package.  However, the environment variable `LINGUAS'
 may be set, prior to configuration, to limit the installed set.
-'LINGUAS' should then contain a space separated list of two-letter
+`LINGUAS' should then contain a space separated list of two-letter
 codes, stating which languages are allowed.
 
-1.2 Using This Package
+1.3 Using This Package
 ======================
 
 As a user, if your language has been installed for this package, you
-only have to set the 'LANG' environment variable to the appropriate
-'LL_CC' combination.  If you happen to have the 'LC_ALL' or some other
-'LC_xxx' environment variables set, you should unset them before setting
-'LANG', otherwise the setting of 'LANG' will not have the desired
-effect.  Here 'LL' is an ISO 639 two-letter language code, and 'CC' is
-an ISO 3166 two-letter country code.  For example, let's suppose that
-you speak German and live in Germany.  At the shell prompt, merely
-execute 'setenv LANG de_DE' (in 'csh'), 'export LANG; LANG=de_DE' (in
-'sh') or 'export LANG=de_DE' (in 'bash').  This can be done from your
-'.login' or '.profile' file, once and for all.
+only have to set the `LANG' environment variable to the appropriate
+`LL_CC' combination.  If you happen to have the `LC_ALL' or some other
+`LC_xxx' environment variables set, you should unset them before
+setting `LANG', otherwise the setting of `LANG' will not have the
+desired effect.  Here `LL' is an ISO 639 two-letter language code, and
+`CC' is an ISO 3166 two-letter country code.  For example, let's
+suppose that you speak German and live in Germany.  At the shell
+prompt, merely execute `setenv LANG de_DE' (in `csh'),
+`export LANG; LANG=de_DE' (in `sh') or `export LANG=de_DE' (in `bash').
+This can be done from your `.login' or `.profile' file, once and for
+all.
 
    You might think that the country code specification is redundant.
 But in fact, some languages have dialects in different countries.  For
-example, 'de_AT' is used for Austria, and 'pt_BR' for Brazil.  The
+example, `de_AT' is used for Austria, and `pt_BR' for Brazil.  The
 country code serves to distinguish the dialects.
 
-   The locale naming convention of 'LL_CC', with 'LL' denoting the
-language and 'CC' denoting the country, is the one use on systems based
-on GNU libc.  On other systems, some variations of this scheme are used,
-such as 'LL' or 'LL_CC.ENCODING'.  You can get the list of locales
-supported by your system for your language by running the command
-'locale -a | grep '^LL''.
+   The locale naming convention of `LL_CC', with `LL' denoting the
+language and `CC' denoting the country, is the one use on systems based
+on GNU libc.  On other systems, some variations of this scheme are
+used, such as `LL' or `LL_CC.ENCODING'.  You can get the list of
+locales supported by your system for your language by running the
+command `locale -a | grep '^LL''.
 
    Not all programs have translations for all languages.  By default, an
 English message is shown in place of a nonexistent translation.  If you
 understand other languages, you can set up a priority list of languages.
 This is done through a different environment variable, called
-'LANGUAGE'.  GNU 'gettext' gives preference to 'LANGUAGE' over 'LANG'
-for the purpose of message handling, but you still need to have 'LANG'
+`LANGUAGE'.  GNU `gettext' gives preference to `LANGUAGE' over `LANG'
+for the purpose of message handling, but you still need to have `LANG'
 set to the primary language; this is required by other parts of the
-system libraries.  For example, some Swedish users who would rather read
-translations in German than English for when Swedish is not available,
-set 'LANGUAGE' to 'sv:de' while leaving 'LANG' to 'sv_SE'.
+system libraries.  For example, some Swedish users who would rather
+read translations in German than English for when Swedish is not
+available, set `LANGUAGE' to `sv:de' while leaving `LANG' to `sv_SE'.
 
    Special advice for Norwegian users: The language code for Norwegian
-bokma*l changed from 'no' to 'nb' recently (in 2003).  During the
+bokma*l changed from `no' to `nb' recently (in 2003).  During the
 transition period, while some message catalogs for this language are
-installed under 'nb' and some older ones under 'no', it's recommended
-for Norwegian users to set 'LANGUAGE' to 'nb:no' so that both newer and
+installed under `nb' and some older ones under `no', it's recommended
+for Norwegian users to set `LANGUAGE' to `nb:no' so that both newer and
 older translations are used.
 
-   In the 'LANGUAGE' environment variable, but not in the 'LANG'
-environment variable, 'LL_CC' combinations can be abbreviated as 'LL' to
-denote the language's main dialect.  For example, 'de' is equivalent to
-'de_DE' (German as spoken in Germany), and 'pt' to 'pt_PT' (Portuguese
-as spoken in Portugal) in this context.
+   In the `LANGUAGE' environment variable, but not in the `LANG'
+environment variable, `LL_CC' combinations can be abbreviated as `LL'
+to denote the language's main dialect.  For example, `de' is equivalent
+to `de_DE' (German as spoken in Germany), and `pt' to `pt_PT'
+(Portuguese as spoken in Portugal) in this context.
 
-1.3 Translating Teams
+1.4 Translating Teams
 =====================
 
 For the Free Translation Project to be a success, we need interested
@@ -110,1239 +156,1139 @@ people who like their own language and write it well, and who are also
 able to synergize with other translators speaking the same language.
 Each translation team has its own mailing list.  The up-to-date list of
 teams can be found at the Free Translation Project's homepage,
-'http://translationproject.org/', in the "Teams" area.
+`http://translationproject.org/', in the "Teams" area.
 
    If you'd like to volunteer to _work_ at translating messages, you
 should become a member of the translating team for your own language.
 The subscribing address is _not_ the same as the list itself, it has
-'-request' appended.  For example, speakers of Swedish can send a
-message to 'sv-request@li.org', having this message body:
+`-request' appended.  For example, speakers of Swedish can send a
+message to `sv-request@li.org', having this message body:
 
      subscribe
 
-   Keep in mind that team members are expected to participate _actively_
-in translations, or at solving translational difficulties, rather than
-merely lurking around.  If your team does not exist yet and you want to
-start one, or if you are unsure about what to do or how to get started,
-please write to 'coordinator@translationproject.org' to reach the
-coordinator for all translator teams.
+   Keep in mind that team members are expected to participate
+_actively_ in translations, or at solving translational difficulties,
+rather than merely lurking around.  If your team does not exist yet and
+you want to start one, or if you are unsure about what to do or how to
+get started, please write to `coordinator@translationproject.org' to
+reach the coordinator for all translator teams.
 
    The English team is special.  It works at improving and uniformizing
 the terminology in use.  Proven linguistic skills are praised more than
 programming skills, here.
 
-1.4 Available Packages
+1.5 Available Packages
 ======================
 
 Languages are not equally supported in all packages.  The following
-matrix shows the current state of internationalization, as of Jun 2014.
+matrix shows the current state of internationalization, as of May 2010.
 The matrix shows, in regard of each package, for which languages PO
 files have been submitted to translation coordination, with a
 translation percentage of at least 50%.
 
-     Ready PO files       af am an ar as ast az be bg bn bn_IN bs ca crh cs
+     Ready PO files       af am ar as ast az be be@latin bg bn_IN bs ca crh
                         +---------------------------------------------------+
-     a2ps               |                       []                []     [] |
+     a2ps               |                    []                      []     |
      aegis              |                                                   |
+     ant-phone          |                                                   |
      anubis             |                                                   |
-     aspell             |                []                       []     [] |
-     bash               |                          []             []     [] |
+     aspell             |             []                             []     |
+     bash               |                                                   |
      bfd                |                                                   |
-     binutils           |                                         []        |
+     bibshelf           |             []                                    |
+     binutils           |                                                   |
      bison              |                                                   |
-     bison-runtime      |                []                                 |
-     buzztrax           |                                                [] |
-     ccd2cue            |                                                   |
-     ccide              |                                                   |
+     bison-runtime      |             []                                    |
+     bluez-pin          | []          []                                    |
+     bombono-dvd        |                                                   |
+     buzztard           |                                                   |
      cflow              |                                                   |
      clisp              |                                                   |
-     coreutils          |                                         []     [] |
+     coreutils          |                                []          []     |
      cpio               |                                                   |
      cppi               |                                                   |
-     cpplib             |                                         []        |
-     cryptsetup         |                                                [] |
-     datamash           |                                                   |
-     denemo             |                                         []     [] |
-     dfarc              |                                         []        |
-     dialog             |       []                                []     [] |
+     cpplib             |                                            []     |
+     cryptsetup         |                                                   |
+     dfarc              |                                                   |
+     dialog             |                          []                []     |
      dico               |                                                   |
-     diffutils          |                                                [] |
-     dink               |                                         []        |
-     direvent           |                                                   |
-     doodle             |                                                [] |
-     dos2unix           |                                                   |
-     dos2unix-man       |                                                   |
-     e2fsprogs          |                                         []     [] |
-     enscript           |                                         []        |
-     exif               |                                                [] |
-     fetchmail          |                                         []     [] |
-     findutils          |                                                [] |
-     flex               |                                         []        |
-     freedink           |                                         []     [] |
-     fusionforge        |                                                   |
+     diffutils          |                                            []     |
+     dink               |                                                   |
+     doodle             |                                                   |
+     e2fsprogs          |                                            []     |
+     enscript           |                                            []     |
+     exif               |                                                   |
+     fetchmail          |                                            []     |
+     findutils          |                                []                 |
+     flex               |                                            []     |
+     freedink           |                                                   |
      gas                |                                                   |
-     gawk               |                                         []        |
-     gcal               |                                         []        |
+     gawk               |             []                             []     |
+     gcal               |                                            []     |
      gcc                |                                                   |
-     gdbm               |                                                   |
-     gettext-examples   | []             []        []             []     [] |
-     gettext-runtime    |                          []             []     [] |
-     gettext-tools      |                          []             []        |
+     gettext-examples   | []          []                 []          []     |
+     gettext-runtime    |                    []          []          []     |
+     gettext-tools      |                                []          []     |
+     gip                |                                []                 |
      gjay               |                                                   |
-     glunarclock        |                []        []                    [] |
-     gnubiff            |                                                [] |
-     gnubik             |          []                                       |
-     gnucash            |          ()              ()             []        |
-     gnuchess           |                                                   |
-     gnulib             |                                                [] |
+     gliv               |                                []                 |
+     glunarclock        |             []                 []                 |
+     gnubiff            |                                                   |
+     gnucash            |                                            []     |
+     gnuedu             |                                                   |
+     gnulib             |                                                   |
      gnunet             |                                                   |
      gnunet-gtk         |                                                   |
+     gnutls             |                                                   |
      gold               |                                                   |
-     gphoto2            |                                                [] |
-     gprof              |                          []                       |
+     gpe-aerial         |                                                   |
+     gpe-beam           |                                                   |
+     gpe-bluetooth      |                                                   |
+     gpe-calendar       |                                                   |
+     gpe-clock          |             []                                    |
+     gpe-conf           |                                                   |
+     gpe-contacts       |                                                   |
+     gpe-edit           |                                                   |
+     gpe-filemanager    |                                                   |
+     gpe-go             |                                                   |
+     gpe-login          |                                                   |
+     gpe-ownerinfo      |             []                                    |
+     gpe-package        |                                                   |
+     gpe-sketchbook     |                                                   |
+     gpe-su             |             []                                    |
+     gpe-taskmanager    |             []                                    |
+     gpe-timesheet      |             []                                    |
+     gpe-today          |             []                                    |
+     gpe-todo           |                                                   |
+     gphoto2            |                                                   |
+     gprof              |                                []                 |
+     gpsdrive           |                                                   |
      gramadoir          |                                                   |
-     grep               |                          []             []     [] |
-     grub               |                                         []        |
+     grep               |                                                   |
+     grub               |             []                             []     |
      gsasl              |                                                   |
      gss                |                                                   |
-     gst-plugins-bad    |                          []                    [] |
-     gst-plugins-base   |                          []             []     [] |
-     gst-plugins-good   |                          []             []     [] |
-     gst-plugins-ugly   |                          []             []     [] |
-     gstreamer          |                []        []             []     [] |
-     gtick              |                                                [] |
-     gtkam              |                       []                       [] |
-     gtkspell           | []             []     []                []     [] |
-     guix               |                                                   |
-     guix-packages      |                                                   |
-     gutenprint         |                                         []        |
-     hello              |                                         []        |
+     gst-plugins-bad    |                                []                 |
+     gst-plugins-base   |                                []                 |
+     gst-plugins-good   |                                []                 |
+     gst-plugins-ugly   |                                []                 |
+     gstreamer          | []                             []          []     |
+     gtick              |                                                   |
+     gtkam              |                    []                             |
+     gtkorphan          |                                []                 |
+     gtkspell           | []          []     []                             |
+     gutenprint         |                                                   |
+     hello              |                                []                 |
      help2man           |                                                   |
-     help2man-texi      |                                                   |
      hylafax            |                                                   |
      idutils            |                                                   |
-     iso_15924          |                                                [] |
-     iso_3166           | []          []        [] [] []  []   [] [] []  [] |
+     indent             |                                []          []     |
+     iso_15924          |                                                   |
+     iso_3166           | []       []        []          []  []   [] [] []  |
      iso_3166_2         |                                                   |
-     iso_4217           |                                                [] |
-     iso_639            |             [] []     [] [] []  []      [] []  [] |
-     iso_639_3          |                []                          []     |
-     iso_639_5          |                                                   |
+     iso_4217           |                                                   |
+     iso_639            |          [] []     []              []         []  |
+     iso_639_3          |                                               []  |
      jwhois             |                                                   |
-     kbd                |                                                [] |
-     klavaro            |          []              [] []          []     [] |
-     ld                 |                          []                       |
-     leafpad            |                       [] []             []     [] |
-     libc               |                          []             []     [] |
-     libexif            |                       ()                          |
+     kbd                |                                                   |
+     keytouch           |                                            []     |
+     keytouch-editor    |                                                   |
+     keytouch-keyboa... |                                            []     |
+     klavaro            |       []                                          |
+     latrine            |                                                   |
+     ld                 |                                []                 |
+     leafpad            |                                []          []     |
+     libc               |                                []          []     |
+     libexif            |                    ()                             |
      libextractor       |                                                   |
-     libgnutls          |                                                [] |
-     libgphoto2         |                                                [] |
-     libgphoto2_port    |                                                [] |
+     libgnutls          |                                                   |
+     libgpewidget       |                                                   |
+     libgpg-error       |                                                   |
+     libgphoto2         |                                                   |
+     libgphoto2_port    |                                                   |
      libgsasl           |                                                   |
-     libiconv           |                          []                    [] |
-     libidn             |                                                [] |
-     liferea            |          []    []                       []     [] |
-     lilypond           |                                         []     [] |
-     lordsawar          |                                         []        |
+     libiconv           |                                []                 |
+     libidn             |                                                   |
+     lifelines          |                                                   |
+     liferea            |                          []                []     |
+     lilypond           |                                                   |
+     linkdr             |       []                                          |
+     lordsawar          |                                                   |
      lprng              |                                                   |
-     lynx               |                                         []     [] |
-     m4                 |                                                [] |
+     lynx               |                                            []     |
+     m4                 |                                                   |
      mailfromd          |                                                   |
      mailutils          |                                                   |
-     make               |                                                [] |
-     man-db             |                                         []     [] |
+     make               |                                                   |
+     man-db             |                                                   |
      man-db-manpages    |                                                   |
-     midi-instruments   |          []                             []     [] |
-     minicom            |                                                [] |
-     mkisofs            |                                                [] |
-     myserver           |                                                [] |
-     nano               |                          []             []     [] |
+     minicom            |                                                   |
+     mkisofs            |                                                   |
+     myserver           |                                                   |
+     nano               |                                []          []     |
      opcodes            |                                                   |
-     parted             |                                                [] |
+     parted             |                                                   |
      pies               |                                                   |
-     pnmixer            |                                                   |
-     popt               |                                                [] |
-     procps-ng          |                                                   |
-     procps-ng-man      |                                                   |
-     psmisc             |                                                [] |
-     pspp               |                                         []        |
-     pushover           |                                                [] |
+     popt               |                                                   |
+     psmisc             |                                                   |
+     pspp               |                                            []     |
      pwdutils           |                                                   |
-     pyspread           |                                                   |
-     radius             |                                         []        |
-     recode             |                       []                []     [] |
-     recutils           |                                                   |
+     radius             |                                            []     |
+     recode             |                    []                      []     |
+     rosegarden         |                                                   |
      rpm                |                                                   |
      rush               |                                                   |
      sarg               |                                                   |
-     sed                |                []        []             []     [] |
-     sharutils          |                                                [] |
+     screem             |                                                   |
+     scrollkeeper       |                 [] []                      []     |
+     sed                |             []                             []     |
+     sharutils          |                                []          []     |
      shishi             |                                                   |
-     skribilo           |                                                   |
-     solfege            |                                         []     [] |
+     skencil            |                                                   |
+     solfege            |                                                   |
      solfege-manual     |                                                   |
-     spotmachine        |                                                   |
-     sudo               |                                         []     [] |
-     sudoers            |                                         []     [] |
-     sysstat            |                                                [] |
-     tar                |                          []             []     [] |
-     texinfo            |                                         []     [] |
-     texinfo_document   |                                         []     [] |
-     tigervnc           |                          []                       |
+     soundtracker       |                                                   |
+     sp                 |                                                   |
+     sysstat            |                                                   |
+     tar                |                                []                 |
+     texinfo            |                                                   |
      tin                |                                                   |
-     tin-man            |                                                   |
-     tracgoogleappsa... |                                                   |
-     trader             |                                                   |
-     util-linux         |                                                [] |
-     ve                 |                                                   |
+     unicode-han-tra... |                                                   |
+     unicode-transla... |                                                   |
+     util-linux-ng      |                                            []     |
      vice               |                                                   |
      vmm                |                                                   |
-     vorbis-tools       |                                                [] |
+     vorbis-tools       |                                                   |
      wastesedge         |                                                   |
-     wcd                |                                                   |
-     wcd-man            |                                                   |
-     wdiff              |                                         []     [] |
-     wget               |                                                [] |
+     wdiff              |                                                   |
+     wget               |                    []                      []     |
      wyslij-po          |                                                   |
-     xboard             |                                                   |
-     xdg-user-dirs      | []    []    [] []     [] []     []      [] []  [] |
-     xkeyboard-config   |                          []             []     [] |
+     xchat              |             []     []          []          []     |
+     xdg-user-dirs      | []       [] []     []    []    []  []      [] []  |
+     xkeyboard-config   |                                []          [] []  |
                         +---------------------------------------------------+
-                          af am an ar as ast az be bg bn bn_IN bs ca crh cs
-                           4  0  2  5  3 11   0  8 25  3   3    1 55  4  74
+                          af am ar as ast az be be@latin bg bn_IN bs ca crh
+                           6  0  2  3 19   1 11     3    28   3    1 38  5
 
-                          da  de  el en en_GB en_ZA eo es et eu fa fi  fr 
-                        +--------------------------------------------------+
-     a2ps               | []  []  []     []         [] [] []       []  []  |
-     aegis              | []  []                       []              []  |
-     anubis             | []  []                       []          []  []  |
-     aspell             | []  []         []         [] []          []  []  |
-     bash               |                           [] []              []  |
-     bfd                | []                           []          []  []  |
-     binutils           |                              []          []  []  |
-     bison              | []  []  []                [] [] []       []  []  |
-     bison-runtime      | []  []  []                [] [] []       []  []  |
-     buzztrax           | []  []                                   []  []  |
-     ccd2cue            | []  []                    []                 []  |
-     ccide              | []  []                    [] []          []  []  |
-     cflow              | []  []                    []             []  []  |
-     clisp              | []  []     []                []              []  |
-     coreutils          | []  []                       [] []           []  |
-     cpio               | []  []                       []          []  []  |
-     cppi               | []  []                    []             []  []  |
-     cpplib             | []  []                    [] []          []  []  |
-     cryptsetup         | []  []                       []          []  []  |
-     datamash           | []  []                    []                 []  |
-     denemo             | []                                               |
-     dfarc              | []  []                    [] []          []  []  |
-     dialog             | []  []  []                [] []    [] [] []  []  |
-     dico               | []  []                                   []  []  |
-     diffutils          | []  []  []                [] []              []  |
-     dink               | []  []                    [] []          []  []  |
-     direvent           | []  []                    []                 []  |
-     doodle             | []  []                    []             []      |
-     dos2unix           | []  []                    [] []              []  |
-     dos2unix-man       |     []                       []              []  |
-     e2fsprogs          | []  []                    [] []              []  |
-     enscript           | []  []         []         []             []  []  |
-     exif               | []  []                    [] []          []  []  |
-     fetchmail          | []  ()  []     []         [] []              []  |
-     findutils          | []  []  []                [] [] []       []  []  |
-     flex               | []  []                    [] []          []  []  |
-     freedink           | []  []  []                [] []    []    []  []  |
-     fusionforge        |     []                       []              []  |
-     gas                |                              []          []  []  |
-     gawk               | []  []                       []          []  []  |
-     gcal               | []  []                       []              []  |
-     gcc                |     []                                           |
-     gdbm               | []  []                    []             []  []  |
-     gettext-examples   | []  []  []                [] []          []  []  |
-     gettext-runtime    | []  []                    [] []          []  []  |
-     gettext-tools      | []  []                       []          []  []  |
-     gjay               |     []                    []             []  []  |
-     glunarclock        | []  []                    []             []  []  |
-     gnubiff            |     ()                    []             []  ()  |
-     gnubik             | []  []                    []             []  []  |
-     gnucash            | []  ()  ()     ()            ()          ()  ()  |
-     gnuchess           |     []                    [] []              []  |
-     gnulib             | []  []                    [] [] []       []  []  |
-     gnunet             |                              []                  |
-     gnunet-gtk         |     []                                           |
-     gold               |                              []          []  []  |
-     gphoto2            | []  ()                    []                 []  |
-     gprof              | []  []                    [] []          []  []  |
-     gramadoir          | []  []                    []             []  []  |
-     grep               | []  []                    [] [] []       []  []  |
-     grub               | []  []                       []          []  []  |
-     gsasl              | []  []                    []             []  []  |
-     gss                | []  []                    []             []  []  |
-     gst-plugins-bad    | []  []                                       []  |
-     gst-plugins-base   | []  []  []                   []          []  []  |
-     gst-plugins-good   | []  []  []                   []    []    []  []  |
-     gst-plugins-ugly   | []  []  []                [] []    []    []  []  |
-     gstreamer          | []  []  []                   []    []    []  []  |
-     gtick              | []  ()                    []             []  []  |
-     gtkam              | []  ()                    [] []          []  []  |
-     gtkspell           | []  []  []                [] []    []    []  []  |
-     guix               | []                        []                     |
-     guix-packages      |                                                  |
-     gutenprint         | []  []                                   []  []  |
-     hello              | []  []  []                [] [] []       []  []  |
-     help2man           | []  []  []                [] []          []  []  |
-     help2man-texi      |     []                       []              []  |
-     hylafax            |     []                       []                  |
-     idutils            | []  []                    []             []  []  |
-     iso_15924          | []  ()                    [] []    ()    []  ()  |
-     iso_3166           | []  ()  []                [] [] [] ()    []  ()  |
-     iso_3166_2         | []  ()                             ()        ()  |
-     iso_4217           | []  ()  []                   [] [] ()    []  ()  |
-     iso_639            | []  ()                    [] []    ()    []  ()  |
-     iso_639_3          |     ()                             ()        ()  |
-     iso_639_5          |     ()                             ()        ()  |
-     jwhois             |     []                    [] []          []  []  |
-     kbd                | []  []  []                [] []              []  |
-     klavaro            | []  []  []                [] []    []        []  |
-     ld                 | []                           []          []  []  |
-     leafpad            | []  []  []                [] []    []    []  []  |
-     libc               | []  []                       []          []  []  |
-     libexif            | []  []         ()            []              []  |
-     libextractor       |     []                                           |
-     libgnutls          |     []                    []             []  []  |
-     libgphoto2         | []  ()                                       []  |
-     libgphoto2_port    | []  ()                       []    []    []  []  |
-     libgsasl           | []  []                    []             []  []  |
-     libiconv           | []  []                    [] [] []       []  []  |
-     libidn             | []  []                    []             []  []  |
-     liferea            | []  ()  []                   []    []    []  []  |
-     lilypond           | []  []  []                [] []              []  |
-     lordsawar          | []  []                                           |
-     lprng              |                                                  |
-     lynx               | []  []                    []    []       []  []  |
-     m4                 | []  []  []                []             []  []  |
-     mailfromd          |                                              []  |
-     mailutils          |     []                       []          []  []  |
-     make               | []  []                       []          []  []  |
-     man-db             | []  []                    []                 []  |
-     man-db-manpages    |     []                                       []  |
-     midi-instruments   | []  []  []                [] [] []    [] []  []  |
-     minicom            | []  []                       []          []  []  |
-     mkisofs            |                           []             []  []  |
-     myserver           |     []                    []             []  []  |
-     nano               | []  []                    [] []    []    []  []  |
-     opcodes            | []  []                       []          []  []  |
-     parted             | []  []                                       []  |
-     pies               |     []                                           |
-     pnmixer            |     []                                       []  |
-     popt               | []  []                    [] []          []  []  |
-     procps-ng          |     []                                       []  |
-     procps-ng-man      |     []                                       []  |
-     psmisc             | []  []  []                []       []    []  []  |
-     pspp               |     []                       []              []  |
-     pushover           |     ()                    [] []              []  |
-     pwdutils           | []  []                                       []  |
-     pyspread           | []  []                                       []  |
-     radius             |                              []              []  |
-     recode             | []  []  []                [] []          []  []  |
-     recutils           |     []                       []          []  []  |
-     rpm                | []  []                    []             []  []  |
-     rush               |     []                                   []  []  |
-     sarg               | []                                           []  |
-     sed                | []  []  []                [] [] []       []  []  |
-     sharutils          |     []                    []    []           []  |
-     shishi             |     []                                   []  []  |
-     skribilo           | []                           []              []  |
-     solfege            | []  []                    [] [] []    [] []  []  |
-     solfege-manual     |     []                    [] [] []           []  |
-     spotmachine        | []  []                    []             []  []  |
-     sudo               | []  []                    [] []          []  []  |
-     sudoers            | []  []  []                []             []  []  |
-     sysstat            | []  []                    [] []          []  []  |
-     tar                | []  []                    [] [] []       []  []  |
-     texinfo            | []  []                    [] []              []  |
-     texinfo_document   |     []                    [] []              []  |
-     tigervnc           | []  []  []                []             []  []  |
-     tin                | []  []                          []           []  |
-     tin-man            |                []                                |
-     tracgoogleappsa... | []  []                    []             []  []  |
-     trader             | []  []         []         []             []  []  |
-     util-linux         | []  []                       []              []  |
-     ve                 |     []                    [] []          []  []  |
-     vice               | ()  ()                                       ()  |
-     vmm                |     []                                   []      |
-     vorbis-tools       | []  []                    []                 []  |
-     wastesedge         | []                                               |
-     wcd                |     []                    [] []          []      |
-     wcd-man            |     []                                           |
-     wdiff              | []  []                    [] [] []       []  []  |
-     wget               |     []                    [] [] []       []  []  |
-     wyslij-po          |     []                    []             []  []  |
-     xboard             | []  []                       []              []  |
-     xdg-user-dirs      | []  []  []                [] [] [] [] [] []  []  |
-     xkeyboard-config   | []  []  []                [] []          []  []  |
-                        +--------------------------------------------------+
-                          da  de  el en en_GB en_ZA eo es et eu fa fi  fr 
-                          119 131 32  1   6     0   94 95 22 13  4 102 139
-
-                          ga gd gl gu he hi hr hu hy ia id is it ja ka kk
+                          cs da  de  el en en_GB en_ZA eo es et eu fa fi
                         +-------------------------------------------------+
-     a2ps               |                   []          []    [] []       |
-     aegis              |                                     []          |
-     anubis             |                   [] []       []    []          |
-     aspell             | []                []          []    [] []       |
-     bash               |                      []       []    [] []       |
-     bfd                |                               []       []       |
-     binutils           |                               []    [] []       |
-     bison              |                   []                            |
-     bison-runtime      | []    []          [] []    [] []    [] []       |
-     buzztrax           |                                                 |
-     ccd2cue            |                      []                         |
-     ccide              |                   [] []                         |
-     cflow              | []                []          []                |
-     clisp              |                                                 |
-     coreutils          |                      []                []       |
-     cpio               | []                [] []       []    [] []       |
-     cppi               |       []          [] []             [] []       |
-     cpplib             |                               []       []       |
-     cryptsetup         |                                     []          |
-     datamash           |                                                 |
-     denemo             |                                     []          |
-     dfarc              |                   [] []             []          |
-     dialog             | [] [] []          [] []    [] [] [] [] []       |
+     a2ps               | [] []  []  []     []            [] []       []  |
+     aegis              |    []  []                       []              |
+     ant-phone          |    []  ()                                       |
+     anubis             |    []  []                                   []  |
+     aspell             | [] []  []         []            []              |
+     bash               | []                           [] []          []  |
+     bfd                |                                 []          []  |
+     bibshelf           |    []  []                       []          []  |
+     binutils           |                                 []          []  |
+     bison              |        []  []                               []  |
+     bison-runtime      |    []  []  []                      []       []  |
+     bluez-pin          | [] []  []  []                [] []          []  |
+     bombono-dvd        |    []                                       []  |
+     buzztard           | [] []  []                                       |
+     cflow              |    []  []                                   []  |
+     clisp              |    []  []     []                []              |
+     coreutils          | [] []  []                          []           |
+     cpio               |                                             []  |
+     cppi               |                                             []  |
+     cpplib             |    []  []                       []              |
+     cryptsetup         |        []                                       |
+     dfarc              |    []  []                       []          []  |
+     dialog             |    []  []                    [] []    []        |
      dico               |                                                 |
-     diffutils          |                      []       []    [] []       |
-     dink               |                      []                         |
-     direvent           |                      []                         |
-     doodle             | []                                  []          |
-     dos2unix           |                      []                []       |
-     dos2unix-man       |                                                 |
-     e2fsprogs          |                      []       []                |
-     enscript           | []                []          []                |
-     exif               |       []          []          [] [] [] []       |
-     fetchmail          |                               []    [] []       |
-     findutils          | []    []          [] []       []    [] []       |
-     flex               | []                                              |
-     freedink           |                   [] []       []    []          |
-     fusionforge        |                                                 |
-     gas                |                               []                |
-     gawk               |                               []    () []       |
-     gcal               |                                                 |
-     gcc                |                                                 |
-     gdbm               |                                                 |
-     gettext-examples   | []    []          [] []       []    [] []       |
-     gettext-runtime    | []    []          [] []       []    [] []       |
-     gettext-tools      |                               []    [] []       |
-     gjay               |       []                                        |
-     glunarclock        | []    []          [] []       []    []          |
-     gnubiff            |                      []       []    ()          |
-     gnubik             |       []          []                []          |
-     gnucash            |          () () ()    ()             ()          |
-     gnuchess           |                                                 |
-     gnulib             | []    []             []             [] []       |
+     diffutils          | [] []  []  []                [] []          []  |
+     dink               |    []  []                       []              |
+     doodle             |        []                                       |
+     e2fsprogs          | []     []                       []              |
+     enscript           |    []  []         []                            |
+     exif               | () []  []                                   []  |
+     fetchmail          | [] []  ()  []     []            []              |
+     findutils          | [] []  []                                   []  |
+     flex               |        []                       []          []  |
+     freedink           |    []  []                       []          []  |
+     gas                |                                 []              |
+     gawk               |    []  []                       []              |
+     gcal               |                                 []              |
+     gcc                |        []                       []              |
+     gettext-examples   |        []  []                [] []          []  |
+     gettext-runtime    |    []  []                    [] []          []  |
+     gettext-tools      |        []                       []    []        |
+     gip                |    []  []                       []    []    []  |
+     gjay               |        []                                   []  |
+     gliv               | [] []  []                                   []  |
+     glunarclock        |    []  []                                   []  |
+     gnubiff            |        ()                                       |
+     gnucash            | []     ()  ()     ()            ()          ()  |
+     gnuedu             |    []                           []              |
+     gnulib             |        []                       []          []  |
      gnunet             |                                                 |
-     gnunet-gtk         |                                                 |
-     gold               |                               []    []          |
-     gphoto2            |                      []       []    [] []       |
-     gprof              | []                   []       []    []          |
-     gramadoir          | []                   []       []                |
-     grep               | []    []          [] []       []    [] []       |
-     grub               |       []             []             []          |
-     gsasl              | []                [] []       []    []          |
-     gss                | []                [] []       []    []          |
-     gst-plugins-bad    |                   [] []       []                |
-     gst-plugins-base   |       []          [] []       []                |
-     gst-plugins-good   |       []          [] []       []    [] []       |
-     gst-plugins-ugly   |       []          [] []       []    [] []       |
-     gstreamer          |       []          [] []       []    []          |
-     gtick              | []    []             []       []    []          |
-     gtkam              |                      []       [] [] [] []       |
-     gtkspell           | []    []    []    [] [] []    [] [] [] []       |
-     guix               |                                                 |
-     guix-packages      |                                                 |
-     gutenprint         |       []             []             []          |
-     hello              | []    []          [] []       []                |
-     help2man           |                   []                [] []       |
-     help2man-texi      |                                                 |
-     hylafax            |                               []                |
-     idutils            |                      []       []                |
-     iso_15924          |       []             []    [] [] [] []          |
-     iso_3166           | []    [] [] [] [] [] []    [] [] [] [] []    [] |
-     iso_3166_2         |                               []    []          |
-     iso_4217           |                   [] []       [] [] [] []       |
-     iso_639            | []    [] []       [] []       [] [] [] []       |
-     iso_639_3          |       []                            []          |
-     iso_639_5          |                                                 |
-     jwhois             |       []             []       []    []          |
-     kbd                |                      []       []    []          |
-     klavaro            |       []          [] []             []       [] |
-     ld                 | []                            []    [] []       |
-     leafpad            | []    []    []    [] []       []    [] ()       |
-     libc               |       []          []          []    [] []       |
-     libexif            |                                     []          |
+     gnunet-gtk         |    []                                           |
+     gnutls             | []     []                                       |
+     gold               |                                 []          []  |
+     gpe-aerial         | [] []  []                       []          []  |
+     gpe-beam           | [] []  []                       []          []  |
+     gpe-bluetooth      |    []  []                                   []  |
+     gpe-calendar       |    []                                       []  |
+     gpe-clock          | [] []  []                       []          []  |
+     gpe-conf           | [] []  []                                   []  |
+     gpe-contacts       |    []  []                       []          []  |
+     gpe-edit           |    []  []                                   []  |
+     gpe-filemanager    |    []  []                       []          []  |
+     gpe-go             | [] []  []                       []          []  |
+     gpe-login          |    []  []                                   []  |
+     gpe-ownerinfo      | [] []  []                       []          []  |
+     gpe-package        |    []  []                       []          []  |
+     gpe-sketchbook     | [] []  []                       []          []  |
+     gpe-su             | [] []  []                       []          []  |
+     gpe-taskmanager    | [] []  []                       []          []  |
+     gpe-timesheet      | [] []  []                       []          []  |
+     gpe-today          | [] []  []                       []          []  |
+     gpe-todo           |    []  []                       []          []  |
+     gphoto2            | [] []  ()         []            []    []    []  |
+     gprof              |    []  []                       []          []  |
+     gpsdrive           |    []                           [] []           |
+     gramadoir          |    []  []                    []                 |
+     grep               | []                                          []  |
+     grub               |    []  []                                   []  |
+     gsasl              |        []                                   []  |
+     gss                |                                             []  |
+     gst-plugins-bad    | [] []  []                       []    []    []  |
+     gst-plugins-base   | [] []  []                       []    []    []  |
+     gst-plugins-good   | [] []  []  []                   []    []    []  |
+     gst-plugins-ugly   | [] []  []  []                   []    []    []  |
+     gstreamer          | [] []  []                       []    []    []  |
+     gtick              |    []  ()                    []             []  |
+     gtkam              | [] []  ()                    [] []              |
+     gtkorphan          | [] []  []                    []                 |
+     gtkspell           | [] []  []  []                [] []    []    []  |
+     gutenprint         |    []  []         []                        []  |
+     hello              |    []  []                    [] []          []  |
+     help2man           |        []                                   []  |
+     hylafax            |        []                       []              |
+     idutils            |    []  []                                   []  |
+     indent             | [] []  []                    [] [] [] []    []  |
+     iso_15924          |    []      ()                [] []          []  |
+     iso_3166           | [] []  []  ()                [] [] [] ()    []  |
+     iso_3166_2         |            ()                                   |
+     iso_4217           | [] []  []  ()                   [] []       []  |
+     iso_639            | [] []  []  ()                [] []          []  |
+     iso_639_3          |                                                 |
+     jwhois             |                                 []          []  |
+     kbd                | [] []  []  []                   []              |
+     keytouch           |    []  []                                   []  |
+     keytouch-editor    |    []  []                                   []  |
+     keytouch-keyboa... |    []                                       []  |
+     klavaro            | [] []  []                    []                 |
+     latrine            |    []  ()                                   []  |
+     ld                 |    []                           []          []  |
+     leafpad            | [] []  []  []                   []    []    []  |
+     libc               | [] []  []                       []          []  |
+     libexif            |    []  []         ()                            |
      libextractor       |                                                 |
-     libgnutls          |                                     []          |
-     libgphoto2         |                                     [] []       |
-     libgphoto2_port    |                                     [] []       |
-     libgsasl           | []                   []       []    []          |
-     libiconv           | []    []          [] []       []    [] []       |
-     libidn             |                   [] []       []    []          |
-     liferea            |       []    []       []             [] []       |
-     lilypond           |                                     []          |
-     lordsawar          |                                                 |
-     lprng              |                               []                |
-     lynx               |                      []       []    [] []       |
-     m4                 | []    []          []          []       []       |
+     libgnutls          | []                                              |
+     libgpewidget       |    []  []                                   []  |
+     libgpg-error       | []     []                                       |
+     libgphoto2         |    []  ()                                       |
+     libgphoto2_port    |    []  ()                             []        |
+     libgsasl           |                                             []  |
+     libiconv           | [] []  []                    []    []       []  |
+     libidn             | []     []                    []             []  |
+     lifelines          |    []  ()                                       |
+     liferea            | []     []  []                   []    []        |
+     lilypond           | []     []                       []          []  |
+     linkdr             |    []  []                       []          []  |
+     lordsawar          |    []                                           |
+     lprng              |                                                 |
+     lynx               | [] []  []                          []           |
+     m4                 | [] []  []  []                               []  |
      mailfromd          |                                                 |
-     mailutils          |                                                 |
-     make               |                   []          []    [] []       |
-     man-db             |                               []       []       |
-     man-db-manpages    |                               []       []       |
-     midi-instruments   |       []    []    [] [] []    [] [] [] []       |
-     minicom            |                      []       []       []       |
-     mkisofs            |                               []    []          |
-     myserver           |                                     []          |
-     nano               | []    []          [] []             [] []       |
-     opcodes            | []                            []    []          |
-     parted             |       []             []       []    [] []       |
+     mailutils          |                                 []              |
+     make               |    []  []                       []          []  |
+     man-db             |                                                 |
+     man-db-manpages    |                                                 |
+     minicom            | [] []  []                       []          []  |
+     mkisofs            |                                             []  |
+     myserver           |                                                 |
+     nano               |        []                       []    []    []  |
+     opcodes            |        []                       []          []  |
+     parted             | []     []                                       |
      pies               |                                                 |
-     pnmixer            |                   []                []          |
-     popt               | []    [] []       [] []    [] [] [] [] []       |
-     procps-ng          |                                                 |
-     procps-ng-man      |                                                 |
-     psmisc             |                   [] []       []    []          |
-     pspp               |       []                               []       |
-     pushover           |                                     []          |
-     pwdutils           |                               []                |
-     pyspread           |                                                 |
-     radius             |                               []                |
-     recode             | []    []    []    [] []       []    []          |
-     recutils           |                                                 |
-     rpm                |                               []                |
-     rush               |       []                                        |
+     popt               | [] []  []                    [] []          []  |
+     psmisc             | []     []                             []    []  |
+     pspp               |                                 []              |
+     pwdutils           |    []                                           |
+     radius             |                                 []              |
+     recode             | [] []  []  []                [] []          []  |
+     rosegarden         | ()     ()                       ()          ()  |
+     rpm                |    []  []                       []              |
+     rush               |                                                 |
      sarg               |                                                 |
-     sed                | []    []          [] []       []    [] []       |
-     sharutils          |                                                 |
+     screem             |                                                 |
+     scrollkeeper       | [] []  []         []            []          []  |
+     sed                | []     []  []                [] [] []       []  |
+     sharutils          |    []  []                       [] []       []  |
      shishi             |                                                 |
-     skribilo           |                      []                         |
-     solfege            |       []                            []          |
-     solfege-manual     |                                                 |
-     spotmachine        |                                                 |
-     sudo               |       []          []                [] []       |
-     sudoers            |                   []                [] []       |
-     sysstat            |                   [] []       []       []       |
-     tar                | []                [] []       []    [] []       |
-     texinfo            |                   []          []    []          |
-     texinfo_document   |                   [] []             []          |
-     tigervnc           |                                                 |
-     tin                |                                                 |
-     tin-man            |                                                 |
-     tracgoogleappsa... |       []    []    [] []                         |
-     trader             |                   [] []                         |
-     util-linux         |                                        []       |
-     ve                 |                                     []          |
-     vice               |                      ()             ()          |
-     vmm                |                                                 |
-     vorbis-tools       |                   []          []                |
-     wastesedge         |                                     []          |
-     wcd                |                                                 |
-     wcd-man            |                                                 |
-     wdiff              |       []             []             []          |
-     wget               |                   [] []             [] []       |
-     wyslij-po          |       []          []          []                |
-     xboard             |                                                 |
-     xdg-user-dirs      | [] [] [] [] [] [] [] []    [] [] [] [] []    [] |
-     xkeyboard-config   |       []          [] []       []    [] []       |
+     skencil            |    []  ()                       []              |
+     solfege            |        []                    []    []       []  |
+     solfege-manual     |                              []    []           |
+     soundtracker       |    []  []                       []              |
+     sp                 |        []                                       |
+     sysstat            |    []  []                             []    []  |
+     tar                | []     []                          [] []    []  |
+     texinfo            |        []                    [] []              |
+     tin                |        []                          []           |
+     unicode-han-tra... |                                                 |
+     unicode-transla... |                                                 |
+     util-linux-ng      | [] []  []                       []          []  |
+     vice               |    ()  ()                                       |
+     vmm                |        []                                       |
+     vorbis-tools       | []                           []                 |
+     wastesedge         |    []                                           |
+     wdiff              |        []                       []          []  |
+     wget               | []     []                          []       []  |
+     wyslij-po          |                                             []  |
+     xchat              | []     []  []                   [] []       []  |
+     xdg-user-dirs      | [] []  []  []                [] [] [] []    []  |
+     xkeyboard-config   | [] []  []                    [] []          []  |
                         +-------------------------------------------------+
-                          ga gd gl gu he hi hr hu hy ia id is it ja ka kk
-                          35  2 47  4  8  2 60 71  2  6 81 11 87 57  0  3
+                          cs da  de  el en en_GB en_ZA eo es et eu fa fi
+                          64 105 117 18  1   8     0   28 89 18 19  0 104
 
-                          kn ko ku ky lg lt lv mk ml mn mr ms mt nb ne nl 
-                        +--------------------------------------------------+
-     a2ps               |                                  []          []  |
-     aegis              |                                              []  |
-     anubis             |                                  []    []    []  |
-     aspell             |                            []                []  |
-     bash               |                                        []    []  |
-     bfd                |                                                  |
-     binutils           |                                                  |
-     bison              |                                              []  |
-     bison-runtime      |          []    [] []             []    []    []  |
-     buzztrax           |                                                  |
-     ccd2cue            |                                                  |
-     ccide              |                   []                         []  |
-     cflow              |                                              []  |
-     clisp              |                                              []  |
-     coreutils          |                                        []    []  |
-     cpio               |                                              []  |
-     cppi               |                                                  |
-     cpplib             |                                              []  |
-     cryptsetup         |                                              []  |
-     datamash           |                                        []    []  |
-     denemo             |                                                  |
-     dfarc              |                      []                      []  |
-     dialog             |       []       [] []             []    []    []  |
-     dico               |                                                  |
-     diffutils          |                   []                   []    []  |
-     dink               |                                              []  |
-     direvent           |                                              []  |
-     doodle             |                                              []  |
-     dos2unix           |                                        []    []  |
-     dos2unix-man       |                                              []  |
-     e2fsprogs          |                                              []  |
-     enscript           |                                              []  |
-     exif               |    []             []                         []  |
-     fetchmail          |                                              []  |
-     findutils          |                                        []    []  |
-     flex               |                                              []  |
-     freedink           |                                        []    []  |
-     fusionforge        |                                                  |
-     gas                |                                                  |
-     gawk               |                                              []  |
-     gcal               |                                                  |
-     gcc                |                                                  |
-     gdbm               |                                                  |
-     gettext-examples   |          []       []             [] [] []    []  |
-     gettext-runtime    |    []                                  []    []  |
-     gettext-tools      |    []                                            |
-     gjay               |                                                  |
-     glunarclock        |                   []                         []  |
-     gnubiff            |                                              []  |
-     gnubik             |                                        []    []  |
-     gnucash            | () ()          () ()          ()       () () []  |
-     gnuchess           |                                        []    []  |
-     gnulib             |                                              []  |
-     gnunet             |                                                  |
-     gnunet-gtk         |                                                  |
-     gold               |                                                  |
-     gphoto2            |                                              []  |
-     gprof              |                                  []          []  |
-     gramadoir          |                                              []  |
-     grep               |                                        []    []  |
-     grub               |                []                      []    []  |
-     gsasl              |                                              []  |
-     gss                |                                                  |
-     gst-plugins-bad    |                   []                   []    []  |
-     gst-plugins-base   |                   []                   []    []  |
-     gst-plugins-good   |                [] []                   []    []  |
-     gst-plugins-ugly   |                   []             [] [] []    []  |
-     gstreamer          |                []                      []    []  |
-     gtick              |                                              []  |
-     gtkam              |                                        []    []  |
-     gtkspell           |          []    [] []       []    []    []    []  |
-     guix               |                                                  |
-     guix-packages      |                                                  |
-     gutenprint         |                                              []  |
-     hello              |                   []                   []    []  |
-     help2man           |                                        []        |
-     help2man-texi      |                                                  |
-     hylafax            |                                              []  |
-     idutils            |                                              []  |
-     iso_15924          |                () []                         []  |
-     iso_3166           | [] [] []       () [] [] []    []       []    []  |
-     iso_3166_2         |                ()                            []  |
-     iso_4217           |                () []                   []    []  |
-     iso_639            | [] []          () []    []    []             []  |
-     iso_639_3          | []             ()             []                 |
-     iso_639_5          |                ()                                |
-     jwhois             |                   []                         []  |
-     kbd                |                                              []  |
-     klavaro            |                                        []    []  |
-     ld                 |                                                  |
-     leafpad            |    []    []    [] []                         []  |
-     libc               |    []                                        []  |
-     libexif            |                                              []  |
-     libextractor       |                                              []  |
-     libgnutls          |                                  []          []  |
-     libgphoto2         |                                              []  |
-     libgphoto2_port    |                                              []  |
-     libgsasl           |                                              []  |
-     libiconv           |                []                            []  |
-     libidn             |                                              []  |
-     liferea            |                [] []                         []  |
-     lilypond           |                                              []  |
-     lordsawar          |                                                  |
-     lprng              |                                                  |
-     lynx               |                                              []  |
-     m4                 |                                              []  |
-     mailfromd          |                                                  |
-     mailutils          |                                                  |
-     make               |    []                                        []  |
-     man-db             |                                              []  |
-     man-db-manpages    |                                              []  |
-     midi-instruments   |    [] []       []          []    []       [] []  |
-     minicom            |                                        []        |
-     mkisofs            |                                              []  |
-     myserver           |                                                  |
-     nano               |                                  []    []    []  |
-     opcodes            |                                              []  |
-     parted             |    []                                        []  |
-     pies               |                                                  |
-     pnmixer            |                                              []  |
-     popt               | [] []             []                   []    []  |
-     procps-ng          |                                                  |
-     procps-ng-man      |                                                  |
-     psmisc             |                                              []  |
-     pspp               |                []                            []  |
-     pushover           |                                                  |
-     pwdutils           |                                              []  |
-     pyspread           |                                                  |
-     radius             |                                              []  |
-     recode             |                                        []    []  |
-     recutils           |                                              []  |
-     rpm                |                                              []  |
-     rush               |                                              []  |
-     sarg               |                                                  |
-     sed                |                                        []    []  |
-     sharutils          |                                              []  |
-     shishi             |                                                  |
-     skribilo           |                                                  |
-     solfege            |                                        []    []  |
-     solfege-manual     |                                              []  |
-     spotmachine        |                                              []  |
-     sudo               |    []                                  []    []  |
-     sudoers            |    []                                  []    []  |
-     sysstat            |                                        []    []  |
-     tar                |          []                            []    []  |
-     texinfo            |                                              []  |
-     texinfo_document   |                                              []  |
-     tigervnc           |                                              []  |
-     tin                |                                                  |
-     tin-man            |                                                  |
-     tracgoogleappsa... |                   []                   []    []  |
-     trader             |                                        []        |
-     util-linux         |                                              []  |
-     ve                 |                                              []  |
-     vice               |                                              []  |
-     vmm                |                                              []  |
-     vorbis-tools       |                                              []  |
-     wastesedge         |                                              []  |
-     wcd                |                                              []  |
-     wcd-man            |                                              []  |
-     wdiff              |                                              []  |
-     wget               |                                        []    []  |
-     wyslij-po          |                                              []  |
-     xboard             |                                              []  |
-     xdg-user-dirs      | [] [] [] []    [] [] [] []    []       []    []  |
-     xkeyboard-config   |    []          []                            []  |
-                        +--------------------------------------------------+
-                          kn ko ku ky lg lt lv mk ml mn mr ms mt nb ne nl 
-                           5 15  4  6  0 13 23  3  3  3  4 11  2 42  1 125
-
-                          nn or pa pl  ps pt pt_BR ro ru rw sk sl sq sr 
+                          fr  ga gl gu he hi hr hu hy id  is it ja ka kn
                         +------------------------------------------------+
-     a2ps               |          []     []  []   [] []       []    []  |
-     aegis              |                     []      []                 |
-     anubis             |          []                 []             []  |
-     aspell             |          []         []   [] []    [] []    []  |
-     bash               |          []         []      []    [] []    []  |
-     bfd                |                             []             []  |
-     binutils           |                             []             []  |
-     bison              |          []         []                     []  |
-     bison-runtime      |          []     []  []   [] []       [] [] []  |
-     buzztrax           |                     []                         |
-     ccd2cue            |                     []                     []  |
-     ccide              |          []                 []             []  |
-     cflow              |          []         []                     []  |
-     clisp              |                             []                 |
-     coreutils          |          []                 []       []    []  |
-     cpio               |          []                 []             []  |
-     cppi               |          []         []                     []  |
-     cpplib             |                     []      []             []  |
-     cryptsetup         |          []         []                     []  |
-     datamash           |                     []                     []  |
-     denemo             |                                                |
-     dfarc              |          []         []                     []  |
-     dialog             |          []         []   [] []    [] []    []  |
-     dico               |          []                                    |
-     diffutils          |          []         []                     []  |
-     dink               |                                                |
-     direvent           |          []         []                     []  |
-     doodle             |                                         [] []  |
-     dos2unix           |          []         []      []             []  |
-     dos2unix-man       |          []         []                         |
-     e2fsprogs          |          []                                    |
-     enscript           |          []         []   [] []       []    []  |
-     exif               |          []         []   [] []    []       []  |
-     fetchmail          |          []                 []          []     |
-     findutils          |          []         []      []    [] []    []  |
-     flex               |          []         []   [] []             []  |
-     freedink           |          []         []      []       []    []  |
-     fusionforge        |                                                |
-     gas                |                                                |
-     gawk               |          []                                    |
-     gcal               |                                                |
-     gcc                |                                                |
-     gdbm               |          []         []                     []  |
-     gettext-examples   |          []     []  []   [] []    [] []    []  |
-     gettext-runtime    | []       []     []  []   [] []    [] []    []  |
-     gettext-tools      |          []         []   [] []    [] []    []  |
-     gjay               |                                            []  |
-     glunarclock        |          []         []   []       [] []    []  |
-     gnubiff            |                                            []  |
-     gnubik             |          []         []               []    []  |
-     gnucash            |          ()     ()  ()   () ()             []  |
-     gnuchess           |                     []                     []  |
-     gnulib             |          []         []      []       []    []  |
+     a2ps               | []                          []        []       |
+     aegis              | []                                 []          |
+     ant-phone          | []                                 []          |
+     anubis             | []                          []     []          |
+     aspell             | []  []                      []     []          |
+     bash               | []                          []        []       |
+     bfd                | []                          []                 |
+     bibshelf           | []  []                      []     []          |
+     binutils           | []                          []                 |
+     bison              | []  []                      []                 |
+     bison-runtime      | []  []                      []     [] []       |
+     bluez-pin          | []  []                [] [] []  []    []       |
+     bombono-dvd        |                                                |
+     buzztard           |                             []                 |
+     cflow              |     []                      []                 |
+     clisp              | []                                             |
+     coreutils          | []  []                []    []     []          |
+     cpio               | []  []                      []                 |
+     cppi               | []                                             |
+     cpplib             | []                          []                 |
+     cryptsetup         | []                          []     []          |
+     dfarc              | []                                 []          |
+     dialog             | []  [] []                   []  [] [] []       |
+     dico               |                                                |
+     diffutils          | []  [] []    []       []    []     [] []       |
+     dink               | []                                             |
+     doodle             |     []                             []          |
+     e2fsprogs          | []                          []                 |
+     enscript           | []  []             []       []                 |
+     exif               | []                          []  [] [] []       |
+     fetchmail          | []                          []     [] []       |
+     findutils          | []  []                []    []     []          |
+     flex               | []  []                                         |
+     freedink           | []                          []                 |
+     gas                | []                          []                 |
+     gawk               | []  []       []             []     () []       |
+     gcal               | []                                             |
+     gcc                |                             []                 |
+     gettext-examples   | []  []                []    []     [] []       |
+     gettext-runtime    | []  []                      []     [] []       |
+     gettext-tools      | []                          []     [] []       |
+     gip                | []  [] []                   []        []       |
+     gjay               |                                                |
+     gliv               | ()                                             |
+     glunarclock        |     []                []    []                 |
+     gnubiff            | ()                          []     ()          |
+     gnucash            | ()           ()       ()           () []       |
+     gnuedu             | []                                 []          |
+     gnulib             | []  []                []           [] []       |
      gnunet             |                                                |
-     gnunet-gtk         |                                                |
-     gold               |                                                |
-     gphoto2            |          []         []   [] []             []  |
-     gprof              |                     []   [] []             []  |
-     gramadoir          |                                   []       []  |
-     grep               |          []         []      []    [] []    []  |
-     grub               |          []         []      []       []    []  |
-     gsasl              |          []                       []       []  |
-     gss                |          []              []       []       []  |
-     gst-plugins-bad    |          []         []      []    []       []  |
-     gst-plugins-base   |          []         []      []    [] []    []  |
-     gst-plugins-good   |          []         []   [] []    [] []    []  |
-     gst-plugins-ugly   |          []         []   [] []    [] []    []  |
-     gstreamer          |          []         []   [] []    [] []    []  |
-     gtick              |          []         []      []    []       []  |
-     gtkam              |       [] []         []      []    []       []  |
-     gtkspell           |          []     []  []   [] []    [] [] [] []  |
-     guix               |                                                |
-     guix-packages      |                                                |
-     gutenprint         |                                   [] []        |
-     hello              |          []         []      []    [] []    []  |
-     help2man           |          []         []      []             []  |
-     help2man-texi      |          []                                    |
-     hylafax            |                                                |
-     idutils            |          []                 []             []  |
-     iso_15924          |          []     ()       [] []       []    []  |
-     iso_3166           | [] [] [] []     ()  []   [] [] [] [] [] [] []  |
-     iso_3166_2         |          []     ()                         []  |
-     iso_4217           | []       []     ()       [] [] []    []    []  |
-     iso_639            |    [] [] []     ()       [] [] [] [] []    []  |
-     iso_639_3          |       []        ()                             |
-     iso_639_5          |                 ()                         []  |
-     jwhois             |          []         []   []                []  |
-     kbd                |          []                 []                 |
-     klavaro            |       [] []         []      []       []        |
-     ld                 |                                                |
-     leafpad            | []       []     []  []      []    [] []    []  |
-     libc               |          []                 []    []           |
-     libexif            |          []         ()            []           |
-     libextractor       |          []                                    |
-     libgnutls          |          []                                    |
-     libgphoto2         |          []                                    |
-     libgphoto2_port    |          []         []      []    []       []  |
-     libgsasl           |          []              []       []       []  |
-     libiconv           |          []         []            [] []    []  |
-     libidn             |          []         []                     []  |
-     liferea            |          []     []  []   [] ()    []    []     |
-     lilypond           |                                                |
+     gnunet-gtk         | []                                             |
+     gnutls             | []                                 []          |
+     gold               |                             []                 |
+     gpe-aerial         | []                          []                 |
+     gpe-beam           | []                          []        []       |
+     gpe-bluetooth      |                             []     [] []       |
+     gpe-calendar       |                                       []       |
+     gpe-clock          | []                    []    []        []       |
+     gpe-conf           | []                          []        []       |
+     gpe-contacts       | []                          []        []       |
+     gpe-edit           |                             []        []       |
+     gpe-filemanager    |                       []    []        []       |
+     gpe-go             | []                    []    []        []       |
+     gpe-login          |                             []        []       |
+     gpe-ownerinfo      | []                    []    []        []       |
+     gpe-package        |                             []        []       |
+     gpe-sketchbook     | []                          []        []       |
+     gpe-su             | []     []             []    []        []       |
+     gpe-taskmanager    | []                    []    []        []       |
+     gpe-timesheet      | []  []                      []        []       |
+     gpe-today          | []  [] []             []    []        []       |
+     gpe-todo           |                             []        []       |
+     gphoto2            | []                    []    []     [] []       |
+     gprof              | []  []                      []                 |
+     gpsdrive           |        []                   []     []          |
+     gramadoir          | []  []                      []                 |
+     grep               |                                    []          |
+     grub               |                       []    []     []          |
+     gsasl              | []  []                      []     []          |
+     gss                | []  []                      []     []          |
+     gst-plugins-bad    | []                    []    []     []          |
+     gst-plugins-base   | []                    []    []     [] []       |
+     gst-plugins-good   | []                    []    []     [] []       |
+     gst-plugins-ugly   | []                    []    []     [] []       |
+     gstreamer          | []                    []    []     []          |
+     gtick              | []  []                      []     []          |
+     gtkam              | []                    []    []     [] []       |
+     gtkorphan          | []                          []     []          |
+     gtkspell           | []  [] []             [] [] []     [] []       |
+     gutenprint         | []                    []           []          |
+     hello              |     []                      []                 |
+     help2man           | []                                             |
+     hylafax            |                             []                 |
+     idutils            | []  []                []    []     []          |
+     indent             | []  [] []             []    []     [] []       |
+     iso_15924          | ()                          []     []          |
+     iso_3166           | ()  [] [] [] [] [] [] []    []     [] []       |
+     iso_3166_2         | ()                    []    []     []          |
+     iso_4217           | ()                    []    []     [] []       |
+     iso_639            | ()  []    []          []    []     [] []    [] |
+     iso_639_3          | ()                                 []       [] |
+     jwhois             | []                    []    []     []          |
+     kbd                | []                          []                 |
+     keytouch           | []  []                []    []     []          |
+     keytouch-editor    |     []                []    []     []          |
+     keytouch-keyboa... |     []                []    []     []          |
+     klavaro            |        []             []                       |
+     latrine            |                             []     []          |
+     ld                 | []  []                      []                 |
+     leafpad            | []  []       []       []    []     [] ()       |
+     libc               | []     []                   []        []       |
+     libexif            |                                                |
+     libextractor       |                                                |
+     libgnutls          | []                                 []          |
+     libgpewidget       |     []                      []        []       |
+     libgpg-error       | []                                 []          |
+     libgphoto2         | []                                 [] []       |
+     libgphoto2_port    | []                                 [] []       |
+     libgsasl           | []  []                      []     []          |
+     libiconv           | []  []                      []     [] []       |
+     libidn             | []                          []     []          |
+     lifelines          | ()                                             |
+     liferea            | []                    []           [] []       |
+     lilypond           | []                                             |
+     linkdr             |              []    [] []           []          |
      lordsawar          |                                                |
-     lprng              |          []                                    |
-     lynx               |                     []      []                 |
-     m4                 |          []         []   [] []             []  |
-     mailfromd          |          []                                    |
-     mailutils          |          []                                    |
-     make               |          []         []      []                 |
-     man-db             |          []                 []             []  |
-     man-db-manpages    |          []                 []             []  |
-     midi-instruments   |          []     []  []   [] []    [] []    []  |
-     minicom            |          []         []   [] []                 |
-     mkisofs            |          []                 []             []  |
-     myserver           |                                      []    []  |
-     nano               |          []         []   [] []       []    []  |
-     opcodes            |                                                |
-     parted             |          []         []      []    [] []    []  |
-     pies               |          []                                    |
-     pnmixer            |                             []                 |
-     popt               |          []     []  []      []       []    []  |
-     procps-ng          |          []                                    |
-     procps-ng-man      |          []                                    |
-     psmisc             |          []         []      []             []  |
-     pspp               |          []                 []                 |
-     pushover           |                                                |
-     pwdutils           |          []                                    |
-     pyspread           | []                  []                         |
-     radius             |          []                 []                 |
-     recode             |          []     []  []   [] []    [] []    []  |
-     recutils           |                     []                     []  |
-     rpm                |          []                                    |
-     rush               |          []         []                     []  |
-     sarg               |                     []      []                 |
-     sed                |          []     []  []   [] []    [] []    []  |
-     sharutils          |          []         []                     []  |
-     shishi             |          []                                []  |
-     skribilo           |                                            []  |
-     solfege            |          []         []      []                 |
-     solfege-manual     |          []         []                         |
-     spotmachine        |                     []                     []  |
-     sudo               |          []         []      []    [] []    []  |
-     sudoers            |          []         []               []    []  |
-     sysstat            |          []         []      []    []       []  |
-     tar                |          []         []      []       []    []  |
-     texinfo            |          []         []      []                 |
-     texinfo_document   |          []         []                         |
-     tigervnc           |                     []      []             []  |
-     tin                |                             []                 |
-     tin-man            |                                                |
-     tracgoogleappsa... |          []         []      []             []  |
-     trader             |                             []             []  |
-     util-linux         |          []         []                         |
-     ve                 |          []         []                     []  |
-     vice               |                                                |
-     vmm                |                                                |
-     vorbis-tools       |          []                          []    []  |
-     wastesedge         |                                                |
-     wcd                |                                                |
-     wcd-man            |                                                |
-     wdiff              |          []         []      []       []    []  |
-     wget               |          []         []      []    []       []  |
-     wyslij-po          | []       []         []                     []  |
-     xboard             |          []                 []             []  |
-     xdg-user-dirs      | [] [] [] []  [] []  []   [] []    [] [] [] []  |
-     xkeyboard-config   |          []         []      []       []        |
+     lprng              |                             []                 |
+     lynx               | []                    []    []     [] []       |
+     m4                 | []  [] []                   []        []       |
+     mailfromd          |                                                |
+     mailutils          | []                          []                 |
+     make               | []  [] []    []    []       []     [] []       |
+     man-db             |                             []     []          |
+     man-db-manpages    |                             []                 |
+     minicom            | []                    []    []        []       |
+     mkisofs            | []                          []     []          |
+     myserver           |                                                |
+     nano               | []  [] []             []           []          |
+     opcodes            | []  []                      []                 |
+     parted             | []                          []     [] []       |
+     pies               |                                                |
+     popt               | []  [] []             []    []  [] [] []       |
+     psmisc             | []                          []                 |
+     pspp               |                                                |
+     pwdutils           | []                          []                 |
+     radius             | []                          []                 |
+     recode             | []  [] []    []       []    []     []          |
+     rosegarden         | ()                          ()     () ()       |
+     rpm                |                             []        []       |
+     rush               |                                                |
+     sarg               | []                                             |
+     screem             |                                    [] []       |
+     scrollkeeper       |                       []    []     []          |
+     sed                | []  [] []             []    []     [] []       |
+     sharutils          | []  []                []    []     [] []       |
+     shishi             | []                                             |
+     skencil            | []                                             |
+     solfege            | []     []                          []          |
+     solfege-manual     | []     []                                      |
+     soundtracker       | []                                 []          |
+     sp                 | []                                    ()       |
+     sysstat            | []                          []     [] []       |
+     tar                | []  []                []    []     [] []       |
+     texinfo            | []                          []     [] []       |
+     tin                | []                                             |
+     unicode-han-tra... |                                                |
+     unicode-transla... | []  []                                         |
+     util-linux-ng      | []                    []    []     [] []       |
+     vice               | ()                    ()           ()          |
+     vmm                | []                                             |
+     vorbis-tools       |                             []                 |
+     wastesedge         | ()                                 ()          |
+     wdiff              |                                                |
+     wget               | []  []             [] []    []     [] []       |
+     wyslij-po          | []                          []                 |
+     xchat              | []        []    []    []    []     [] []    [] |
+     xdg-user-dirs      | []  [] [] [] []       []    []  [] [] []    [] |
+     xkeyboard-config   | []                    []    []     []          |
                         +------------------------------------------------+
-                          nn or pa pl  ps pt pt_BR ro ru rw sk sl sq sr 
-                           7  3  6 114  1 12  88   32 82  3 40 45  7 101
+                          fr  ga gl gu he hi hr hu hy id  is it ja ka kn
+                          121 53 20  4  8  2  5 53  2 120  5 83 66  0  4
 
-                          sv  sw ta te tg th tr uk  ur vi  wa wo zh_CN
-                        +----------------------------------------------+
-     a2ps               | []              [] [] []     []              |
-     aegis              |                              []              |
-     anubis             | []                 [] []     []              |
-     aspell             | []                    []     []  []     []   |
-     bash               | []                    []     []         []   |
-     bfd                | []                    []     []              |
-     binutils           | []                    []     []              |
-     bison              | []                    []     []         []   |
-     bison-runtime      | []              [] [] []     []         []   |
-     buzztrax           | []                           []         []   |
-     ccd2cue            |                       []     []         []   |
-     ccide              | []                    []     []         []   |
-     cflow              | []                    []     []         []   |
-     clisp              |                                              |
-     coreutils          | []                    []     []              |
-     cpio               | []                 [] []     []         []   |
-     cppi               | []                    []     []         []   |
-     cpplib             | []                 [] []     []         []   |
-     cryptsetup         |                       []     []         []   |
-     datamash           | []                    []     []              |
-     denemo             |                                         []   |
-     dfarc              | []                           []              |
-     dialog             | []  []          []           []  []     []   |
-     dico               |                       []                     |
-     diffutils          | []                 [] []     []         []   |
-     dink               | []                                           |
-     direvent           |                       []     []              |
-     doodle             | []                           []              |
-     dos2unix           | []                    []     []         []   |
-     dos2unix-man       | []                    []                []   |
-     e2fsprogs          | []                    []     []         []   |
-     enscript           | []                 [] []     []              |
-     exif               | []                 [] []     []         []   |
-     fetchmail          | []                 []        []         []   |
-     findutils          | []                 [] []     []         []   |
-     flex               | []                 []        []         []   |
-     freedink           | []              []           []              |
-     fusionforge        |                                              |
-     gas                |                       []                     |
-     gawk               | []                           []         []   |
-     gcal               | []                 []                   []   |
-     gcc                | []                                           |
-     gdbm               |                       []     []              |
-     gettext-examples   | []                 [] []     []         []   |
-     gettext-runtime    | []                 [] []     []         []   |
-     gettext-tools      | []                 [] []     []         []   |
-     gjay               |                 []           []         []   |
-     glunarclock        | []                           []  []     []   |
-     gnubiff            | []                           []              |
-     gnubik             | []                    []     []         []   |
-     gnucash            |        () ()              () ()         []   |
-     gnuchess           |                       []     []         []   |
-     gnulib             | []                    []     []         []   |
-     gnunet             |                                              |
-     gnunet-gtk         |                                              |
-     gold               |                       []     []              |
-     gphoto2            | []                    []     []         []   |
-     gprof              | []                 [] []     []              |
-     gramadoir          | []                           []         []   |
-     grep               | []              []    []     []         []   |
-     grub               | []                 [] []     []              |
-     gsasl              | []                    []     []         []   |
-     gss                | []                           []         []   |
-     gst-plugins-bad    | []                 [] []     []         []   |
-     gst-plugins-base   | []                 [] []     []         []   |
-     gst-plugins-good   | []                 [] []     []         []   |
-     gst-plugins-ugly   | []                 [] []     []         []   |
-     gstreamer          | []                 [] []     []         []   |
-     gtick              |                       []     []         []   |
-     gtkam              | []                    []     []         []   |
-     gtkspell           | []              [] [] []     []  []     []   |
-     guix               |                                              |
-     guix-packages      |                                              |
-     gutenprint         |                    [] []     []         []   |
-     hello              | []              [] [] []     []         []   |
-     help2man           |                       []     []         []   |
-     help2man-texi      |                       []                     |
-     hylafax            |                              []              |
-     idutils            |                       []     []         []   |
-     iso_15924          | []              () [] []     ()         []   |
-     iso_3166           | []        []    () [] []     ()  []     []   |
-     iso_3166_2         |                 () [] []     ()         []   |
-     iso_4217           | []              () [] []     ()         []   |
-     iso_639            | []     [] []    () [] []     ()  []     []   |
-     iso_639_3          |        []       () [] []     ()              |
-     iso_639_5          |                 ()    []     ()              |
-     jwhois             | []                 []        []         []   |
-     kbd                | []                    []     []         []   |
-     klavaro            | []                    []  [] []     []  []   |
-     ld                 | []                 [] []     []         []   |
-     leafpad            | []              [] [] []     []         []   |
-     libc               | []                 [] []     []         []   |
-     libexif            | []                           []         ()   |
-     libextractor       |                       []     []              |
-     libgnutls          | []                    []     []         []   |
-     libgphoto2         | []                    []     []              |
-     libgphoto2_port    | []                    []     []         []   |
-     libgsasl           | []                    []     []         []   |
-     libiconv           | []                    []     []  []     []   |
-     libidn             | ()                    []     []         []   |
-     liferea            | []                 [] []     []         []   |
-     lilypond           |                              []              |
-     lordsawar          |                                              |
-     lprng              |                              []              |
-     lynx               | []                 [] []     []              |
-     m4                 | []                           []         []   |
-     mailfromd          |                       []     []              |
-     mailutils          |                              []              |
-     make               | []                    []     []         []   |
-     man-db             | []                           []         []   |
-     man-db-manpages    | []                                      []   |
-     midi-instruments   | []              [] [] []     []         []   |
-     minicom            | []                           []              |
-     mkisofs            |                       []     []         []   |
-     myserver           |                              []              |
-     nano               | []                    []     []         []   |
-     opcodes            |                       []     []         []   |
-     parted             | []                 [] []     []         []   |
-     pies               |                       []     []              |
-     pnmixer            |                       []     []         []   |
-     popt               | []     []       [] [] []     []         []   |
-     procps-ng          |                       []     []              |
-     procps-ng-man      |                       []                     |
-     psmisc             | []                    []     []         []   |
-     pspp               |                    [] []                []   |
-     pushover           | []                                           |
-     pwdutils           | []                           []              |
-     pyspread           |                       []                     |
-     radius             |                       []     []              |
-     recode             | []                 []        []         []   |
-     recutils           | []                    []     []              |
-     rpm                | []                    []     []         []   |
-     rush               |                       []     []              |
-     sarg               |                                              |
-     sed                | []                 [] []     []         []   |
-     sharutils          | []                    []     []         []   |
-     shishi             |                              []         []   |
-     skribilo           | []                    []                     |
-     solfege            | []                 []        []         []   |
-     solfege-manual     |                    []                        |
-     spotmachine        | []                    []     []              |
-     sudo               | []                 [] []     []         []   |
-     sudoers            | []                    []     []         []   |
-     sysstat            | []                 [] []     []         []   |
-     tar                | []                 [] []     []         []   |
-     texinfo            |                    [] []     []              |
-     texinfo_document   |                       []                     |
-     tigervnc           | []                    []                []   |
-     tin                |                                         []   |
-     tin-man            |                                              |
-     tracgoogleappsa... | []              []    []     []         []   |
-     trader             | []                                           |
-     util-linux         | []                    []     []         []   |
-     ve                 | []                    []     []         []   |
-     vice               | ()                 ()                        |
-     vmm                |                                              |
-     vorbis-tools       | []                           []              |
-     wastesedge         |                                              |
-     wcd                |                       []     []         []   |
-     wcd-man            |                       []                     |
-     wdiff              | []                    []     []         []   |
-     wget               |                       []     []         []   |
-     wyslij-po          |                       []     []              |
-     xboard             |                       []                []   |
-     xdg-user-dirs      | []     [] []    [] [] []     []         []   |
-     xkeyboard-config   | []                 [] []     []              |
-                        +----------------------------------------------+
-                          sv  sw ta te tg th tr uk  ur vi  wa wo zh_CN
-                          106  1  4  3  0 13 51 115  1 125  7  1  100 
+                          ko ku ky lg lt lv mk ml mn mr ms mt nb nds ne
+                        +-----------------------------------------------+
+     a2ps               |                               []              |
+     aegis              |                                               |
+     ant-phone          |                                               |
+     anubis             |                               []    []        |
+     aspell             |                         []                    |
+     bash               |                                               |
+     bfd                |                                               |
+     bibshelf           |                []             []              |
+     binutils           |                                               |
+     bison              |                               []              |
+     bison-runtime      |       []    [] []             []    []        |
+     bluez-pin          |    [] []    [] []             []              |
+     bombono-dvd        |                                               |
+     buzztard           |                                               |
+     cflow              |                                               |
+     clisp              |                                               |
+     coreutils          |          []                                   |
+     cpio               |                                               |
+     cppi               |                                               |
+     cpplib             |                                               |
+     cryptsetup         |                                               |
+     dfarc              |                   []                          |
+     dialog             |    []       [] []             []    []        |
+     dico               |                                               |
+     diffutils          |                []             []              |
+     dink               |                                               |
+     doodle             |                                               |
+     e2fsprogs          |                                               |
+     enscript           |                                               |
+     exif               |                []                             |
+     fetchmail          |                                               |
+     findutils          |                                               |
+     flex               |                                               |
+     freedink           |                                     []        |
+     gas                |                                               |
+     gawk               |                                               |
+     gcal               |                                               |
+     gcc                |                                               |
+     gettext-examples   |       []       []             [] []           |
+     gettext-runtime    | []                                            |
+     gettext-tools      | []                                            |
+     gip                |                []             []              |
+     gjay               |                                               |
+     gliv               |                                               |
+     glunarclock        |                []                             |
+     gnubiff            |                                               |
+     gnucash            | ()          ()                      ()     () |
+     gnuedu             |                                               |
+     gnulib             |                                               |
+     gnunet             |                                               |
+     gnunet-gtk         |                                               |
+     gnutls             |                               []              |
+     gold               |                                               |
+     gpe-aerial         |                []                             |
+     gpe-beam           |                []                             |
+     gpe-bluetooth      |                []                []           |
+     gpe-calendar       |                []                             |
+     gpe-clock          | []    []       []             [] []           |
+     gpe-conf           | []             []                             |
+     gpe-contacts       | []             []                             |
+     gpe-edit           |                []                             |
+     gpe-filemanager    | []             []                             |
+     gpe-go             | []             []                []           |
+     gpe-login          |                []                             |
+     gpe-ownerinfo      |                []             []              |
+     gpe-package        | []             []                             |
+     gpe-sketchbook     | []             []                             |
+     gpe-su             | []    []       []             [] [] []        |
+     gpe-taskmanager    | [] [] []       []             [] []           |
+     gpe-timesheet      |                []             []              |
+     gpe-today          |       []       []             [] []           |
+     gpe-todo           |                []                   []        |
+     gphoto2            |                                               |
+     gprof              |                               []              |
+     gpsdrive           |                                               |
+     gramadoir          |                                               |
+     grep               |                                               |
+     grub               |                                               |
+     gsasl              |                                               |
+     gss                |                                               |
+     gst-plugins-bad    |                []                []           |
+     gst-plugins-base   |             [] []                             |
+     gst-plugins-good   |                []                []           |
+     gst-plugins-ugly   |             [] []             [] [] []        |
+     gstreamer          |                                               |
+     gtick              |                                               |
+     gtkam              |                                     []        |
+     gtkorphan          |                []                      []     |
+     gtkspell           |       []    [] []       []    []    [] []     |
+     gutenprint         |                                               |
+     hello              | []             []             []              |
+     help2man           |                                               |
+     hylafax            |                                               |
+     idutils            |                                               |
+     indent             |                                               |
+     iso_15924          |             [] []                             |
+     iso_3166           | [] []       () [] [] []    []       []        |
+     iso_3166_2         |                                               |
+     iso_4217           |             []                      []        |
+     iso_639            |                      []    []                 |
+     iso_639_3          |                            []                 |
+     jwhois             |                []                             |
+     kbd                |                                               |
+     keytouch           |                []                             |
+     keytouch-editor    |                []                             |
+     keytouch-keyboa... |                []                             |
+     klavaro            |                                     []        |
+     latrine            |                []                             |
+     ld                 |                                               |
+     leafpad            | []          [] []                             |
+     libc               | []                                            |
+     libexif            |                                               |
+     libextractor       |                                               |
+     libgnutls          |                               []              |
+     libgpewidget       |                []             []              |
+     libgpg-error       |                                               |
+     libgphoto2         |                                               |
+     libgphoto2_port    |                                               |
+     libgsasl           |                                               |
+     libiconv           |                                               |
+     libidn             |                                               |
+     lifelines          |                                               |
+     liferea            |                                               |
+     lilypond           |                                               |
+     linkdr             |                                               |
+     lordsawar          |                                               |
+     lprng              |                                               |
+     lynx               |                                               |
+     m4                 |                                               |
+     mailfromd          |                                               |
+     mailutils          |                                               |
+     make               | []                                            |
+     man-db             |                                               |
+     man-db-manpages    |                                               |
+     minicom            |                                     []        |
+     mkisofs            |                                               |
+     myserver           |                                               |
+     nano               |                               []    []        |
+     opcodes            |                                               |
+     parted             |                                               |
+     pies               |                                               |
+     popt               | []             []                   []        |
+     psmisc             |                                               |
+     pspp               |                                               |
+     pwdutils           |                                               |
+     radius             |                                               |
+     recode             |                                               |
+     rosegarden         |                                               |
+     rpm                |                                               |
+     rush               |                                               |
+     sarg               |                                               |
+     screem             |                                               |
+     scrollkeeper       |                                     []     [] |
+     sed                |                                               |
+     sharutils          |                                               |
+     shishi             |                                               |
+     skencil            |                                               |
+     solfege            |                                     []        |
+     solfege-manual     |                                               |
+     soundtracker       |                                               |
+     sp                 |                                               |
+     sysstat            |                []                             |
+     tar                |       []                                      |
+     texinfo            |                                     []        |
+     tin                |                                               |
+     unicode-han-tra... |                                               |
+     unicode-transla... |                                               |
+     util-linux-ng      |                                               |
+     vice               |                                               |
+     vmm                |                                               |
+     vorbis-tools       |                                               |
+     wastesedge         |                                               |
+     wdiff              |                                               |
+     wget               |             []                                |
+     wyslij-po          |                                               |
+     xchat              | []             [] []                          |
+     xdg-user-dirs      | [] []       [] [] []       []       [] []     |
+     xkeyboard-config   | []    []    []                                |
+                        +-----------------------------------------------+
+                          ko ku ky lg lt lv mk ml mn mr ms mt nb nds ne
+                          20  5 10  1 12 48  4  2  2  4 24 10 19  3   1
 
-                          zh_HK zh_TW
-                        +-------------+
-     a2ps               |             | 30
-     aegis              |             |  9
-     anubis             |             | 19
-     aspell             |             | 29
-     bash               |        []   | 23
-     bfd                |             | 11
-     binutils           |             | 12
-     bison              |        []   | 18
-     bison-runtime      |        []   | 38
-     buzztrax           |             |  9
-     ccd2cue            |             | 10
-     ccide              |             | 17
-     cflow              |             | 16
-     clisp              |             | 10
-     coreutils          |             | 18
-     cpio               |             | 20
-     cppi               |             | 17
-     cpplib             |        []   | 19
-     cryptsetup         |             | 14
-     datamash           |             | 11
-     denemo             |             |  5
-     dfarc              |             | 17
-     dialog             |        []   | 42
-     dico               |             |  6
-     diffutils          |             | 22
-     dink               |             | 10
-     direvent           |             | 11
-     doodle             |             | 12
-     dos2unix           |        []   | 18
-     dos2unix-man       |             |  9
-     e2fsprogs          |             | 15
-     enscript           |             | 21
-     exif               |             | 27
-     fetchmail          |             | 19
-     findutils          |             | 29
-     flex               |        []   | 19
-     freedink           |             | 24
-     fusionforge        |             |  3
-     gas                |             |  5
-     gawk               |             | 13
-     gcal               |             |  8
-     gcc                |             |  2
-     gdbm               |             | 10
-     gettext-examples   |  []    []   | 40
-     gettext-runtime    |  []    []   | 35
-     gettext-tools      |        []   | 24
-     gjay               |             |  9
-     glunarclock        |        []   | 27
-     gnubiff            |             |  9
-     gnubik             |             | 19
-     gnucash            |        ()   |  6
-     gnuchess           |             | 11
-     gnulib             |             | 23
-     gnunet             |             |  1
-     gnunet-gtk         |             |  1
-     gold               |             |  7
-     gphoto2            |        []   | 19
-     gprof              |             | 21
-     gramadoir          |             | 14
-     grep               |        []   | 31
-     grub               |             | 21
-     gsasl              |        []   | 19
-     gss                |             | 17
-     gst-plugins-bad    |             | 21
-     gst-plugins-base   |             | 27
-     gst-plugins-good   |             | 32
-     gst-plugins-ugly   |             | 34
-     gstreamer          |        []   | 32
-     gtick              |             | 19
-     gtkam              |             | 24
-     gtkspell           |  []    []   | 48
-     guix               |             |  2
-     guix-packages      |             |  0
-     gutenprint         |             | 15
-     hello              |        []   | 30
-     help2man           |             | 18
-     help2man-texi      |             |  5
-     hylafax            |             |  5
-     idutils            |             | 14
-     iso_15924          |        []   | 23
-     iso_3166           |  []    []   | 58
-     iso_3166_2         |             |  9
-     iso_4217           |  []    []   | 28
-     iso_639            |  []    []   | 46
-     iso_639_3          |             | 10
-     iso_639_5          |             |  2
-     jwhois             |        []   | 20
-     kbd                |             | 17
-     klavaro            |             | 30
-     ld                 |        []   | 15
-     leafpad            |        []   | 39
-     libc               |        []   | 24
-     libexif            |             | 10
-     libextractor       |             |  5
-     libgnutls          |             | 13
-     libgphoto2         |             | 10
-     libgphoto2_port    |        []   | 19
-     libgsasl           |             | 18
-     libiconv           |        []   | 29
-     libidn             |             | 17
-     liferea            |             | 29
-     lilypond           |             | 11
-     lordsawar          |             |  3
-     lprng              |             |  3
-     lynx               |             | 19
-     m4                 |        []   | 22
-     mailfromd          |             |  4
-     mailutils          |             |  6
-     make               |             | 19
-     man-db             |             | 15
-     man-db-manpages    |             | 10
-     midi-instruments   |        []   | 43
-     minicom            |        []   | 17
-     mkisofs            |             | 13
-     myserver           |             |  9
-     nano               |        []   | 30
-     opcodes            |             | 12
-     parted             |        []   | 23
-     pies               |             |  4
-     pnmixer            |             |  9
-     popt               |        []   | 36
-     procps-ng          |             |  5
-     procps-ng-man      |             |  4
-     psmisc             |        []   | 22
-     pspp               |             | 13
-     pushover           |             |  6
-     pwdutils           |             |  8
-     pyspread           |             |  6
-     radius             |             |  9
-     recode             |             | 31
-     recutils           |             | 10
-     rpm                |        []   | 13
-     rush               |             | 10
-     sarg               |             |  4
-     sed                |        []   | 35
-     sharutils          |             | 13
-     shishi             |             |  7
-     skribilo           |             |  7
-     solfege            |             | 21
-     solfege-manual     |             |  9
-     spotmachine        |             | 11
-     sudo               |             | 26
-     sudoers            |             | 22
-     sysstat            |             | 23
-     tar                |        []   | 30
-     texinfo            |             | 17
-     texinfo_document   |             | 13
-     tigervnc           |             | 14
-     tin                |        []   |  7
-     tin-man            |             |  1
-     tracgoogleappsa... |        []   | 22
-     trader             |             | 12
-     util-linux         |             | 13
-     ve                 |             | 14
-     vice               |             |  1
-     vmm                |             |  3
-     vorbis-tools       |             | 13
-     wastesedge         |             |  3
-     wcd                |             |  8
-     wcd-man            |             |  3
-     wdiff              |        []   | 23
-     wget               |             | 21
-     wyslij-po          |             | 14
-     xboard             |             | 10
-     xdg-user-dirs      |  []    []   | 68
-     xkeyboard-config   |        []   | 28
-                        +-------------+
-       89 teams           zh_HK zh_TW
-      166 domains           7    42    2809
+                          nl  nn or pa pl  ps pt pt_BR ro ru rw sk sl sq sr
+                        +---------------------------------------------------+
+     a2ps               | []           []     []  []   [] []       []    [] |
+     aegis              | []                      []      []                |
+     ant-phone          |                         []   []                   |
+     anubis             | []           []                 []                |
+     aspell             | []                           [] []    [] []       |
+     bash               | []                                    []          |
+     bfd                |                                 []                |
+     bibshelf           | []  []                                            |
+     binutils           |                                 []    []          |
+     bison              | []           []                 []                |
+     bison-runtime      | []           []     []  []   [] []       []       |
+     bluez-pin          | []           []         []   [] []    [] []    [] |
+     bombono-dvd        |     []                          ()                |
+     buzztard           | []  []                                            |
+     cflow              |              []                                   |
+     clisp              | []                              []                |
+     coreutils          | []           []     []  []      []       []       |
+     cpio               | []           []                 []                |
+     cppi               |              []                                   |
+     cpplib             | []                                                |
+     cryptsetup         | []                                                |
+     dfarc              |              []                                   |
+     dialog             | []           []         []      []                |
+     dico               |              []                                   |
+     diffutils          | []           []         []   [] []             [] |
+     dink               | ()                                                |
+     doodle             | []                                          []    |
+     e2fsprogs          | []           []                                   |
+     enscript           | []                      []   [] []       []       |
+     exif               | []           []              [] ()    []          |
+     fetchmail          | []           []                 []          []    |
+     findutils          | []           []     []          []       []       |
+     flex               | []           []         []   [] []                |
+     freedink           | []           []                                   |
+     gas                |                                                   |
+     gawk               | []           []         []   []                   |
+     gcal               |                                                   |
+     gcc                |                                                [] |
+     gettext-examples   | []           []     []       [] []    [] []    [] |
+     gettext-runtime    | []  []       []     []       [] []    [] []    [] |
+     gettext-tools      |              []              [] []    [] []    [] |
+     gip                | []           []                 []    []       [] |
+     gjay               |                                                   |
+     gliv               | []           []         []   [] []    []          |
+     glunarclock        | []                      []   []       []       [] |
+     gnubiff            | []                           ()                   |
+     gnucash            | []           ()         ()      ()                |
+     gnuedu             | []                                                |
+     gnulib             | []           []                 []       []       |
+     gnunet             |                                                   |
+     gnunet-gtk         |                                                   |
+     gnutls             | []           []                                   |
+     gold               |                                                   |
+     gpe-aerial         | []                  []  []   [] []       []    [] |
+     gpe-beam           | []                  []  []   [] []       []    [] |
+     gpe-bluetooth      | []                      []                        |
+     gpe-calendar       |                         []      []       []    [] |
+     gpe-clock          | []                  []  []   [] []    [] []    [] |
+     gpe-conf           | []                  []  []   [] []    [] []       |
+     gpe-contacts       |                         []   [] []       []    [] |
+     gpe-edit           | []           []                          []       |
+     gpe-filemanager    | []                              []       []       |
+     gpe-go             | []           []         []   [] []    [] []    [] |
+     gpe-login          | []                      []                        |
+     gpe-ownerinfo      | []                  []  []   [] []    [] []    [] |
+     gpe-package        | []                                       []       |
+     gpe-sketchbook     | []                  []  []   [] []       []    [] |
+     gpe-su             | []                  []  []   [] []    [] []    [] |
+     gpe-taskmanager    | []                  []  []   [] []    [] []    [] |
+     gpe-timesheet      | []                  []  []   [] []    [] []    [] |
+     gpe-today          | []                  []  []   [] []    [] []    [] |
+     gpe-todo           | []                      []      []       []    [] |
+     gphoto2            | []        [] []         []   [] []    []       [] |
+     gprof              | []                      []   []                   |
+     gpsdrive           | []                              []                |
+     gramadoir          | []                                    []          |
+     grep               | []           []                 []    []          |
+     grub               | []           []                 []                |
+     gsasl              | []           []                       []       [] |
+     gss                |              []              []       []          |
+     gst-plugins-bad    | []           []         []      []    []          |
+     gst-plugins-base   | []           []         []      []    []          |
+     gst-plugins-good   | []           []         []      []    []          |
+     gst-plugins-ugly   | []           []         []      []    [] []       |
+     gstreamer          | []           []         []      []    []          |
+     gtick              | []                              []    []          |
+     gtkam              | []        [] []         []      []    []          |
+     gtkorphan          | []                                                |
+     gtkspell           | []           []     []  []   [] []    [] [] [] [] |
+     gutenprint         | []                              []                |
+     hello              | []           []                       [] []       |
+     help2man           |              []                 []                |
+     hylafax            | []                                                |
+     idutils            | []           []         []   [] []                |
+     indent             | []           []         []   [] []    []       [] |
+     iso_15924          | []           []                 []       []       |
+     iso_3166           | []  [] [] [] []     ()  []   [] [] [] [] [] [] [] |
+     iso_3166_2         | []           []                          []       |
+     iso_4217           | []  []       []     []          [] []    []    [] |
+     iso_639            | []     [] [] []                 [] [] [] []    [] |
+     iso_639_3          |        [] []                                      |
+     jwhois             | []           []         []   []                   |
+     kbd                | []           []              []                   |
+     keytouch           | []           []                       []          |
+     keytouch-editor    | []           []                       []          |
+     keytouch-keyboa... | []           []                       []          |
+     klavaro            | []                      []                        |
+     latrine            |              []                 []                |
+     ld                 |                                                   |
+     leafpad            | []  []       []     []  []      []    [] []    [] |
+     libc               | []           []                 []    []          |
+     libexif            | []           []         ()            []          |
+     libextractor       |                                                   |
+     libgnutls          | []           []                                   |
+     libgpewidget       | []           []                          []       |
+     libgpg-error       |              []              []                   |
+     libgphoto2         | []           []                                   |
+     libgphoto2_port    | []           []                 []    []          |
+     libgsasl           | []           []              []       []       [] |
+     libiconv           | []           []                       [] []    [] |
+     libidn             | []           []                                   |
+     lifelines          | []           []                                   |
+     liferea            | []           []     []  []   [] ()    ()    []    |
+     lilypond           | []                                                |
+     linkdr             | []                  []          []                |
+     lordsawar          |                                                   |
+     lprng              |              []                                   |
+     lynx               | []                      []      []                |
+     m4                 | []           []         []   [] []                |
+     mailfromd          |              []                                   |
+     mailutils          |              []                                   |
+     make               | []           []         []      []                |
+     man-db             | []           []                 []                |
+     man-db-manpages    | []           []                 []                |
+     minicom            |              []         []   [] []                |
+     mkisofs            | []           []                 []                |
+     myserver           |                                                   |
+     nano               | []           []         []      []                |
+     opcodes            | []                           []                   |
+     parted             | []           []                 []    []          |
+     pies               |              []                                   |
+     popt               | []           []     []          []                |
+     psmisc             | []           []                 []                |
+     pspp               | []                      []                        |
+     pwdutils           |              []                                   |
+     radius             | []           []                 []                |
+     recode             | []           []     []  []   [] []    [] []       |
+     rosegarden         |              ()                 ()                |
+     rpm                | []           []     []                            |
+     rush               | []           []                                   |
+     sarg               |                                                   |
+     screem             |                                                   |
+     scrollkeeper       | []  []       []              [] []    []    [] [] |
+     sed                | []           []     []  []   [] []    [] []    [] |
+     sharutils          | []           []                 []             [] |
+     shishi             |              []                                   |
+     skencil            |                     []  []                        |
+     solfege            | []           []         []      []                |
+     solfege-manual     | []           []         []                        |
+     soundtracker       |                                       []          |
+     sp                 |                                                   |
+     sysstat            | []           []         []      []                |
+     tar                | []           []                 []       []       |
+     texinfo            | []           []              [] []                |
+     tin                |                                 []                |
+     unicode-han-tra... |                                                   |
+     unicode-transla... |                                                   |
+     util-linux-ng      | []           []         []      []       []       |
+     vice               | []                                                |
+     vmm                | []                                                |
+     vorbis-tools       | []           []                                   |
+     wastesedge         | []                                                |
+     wdiff              | []           []                                   |
+     wget               | []           []     []  []      []    [] []       |
+     wyslij-po          | []  []       []                                   |
+     xchat              | []        [] []     []          []    [] [] [] [] |
+     xdg-user-dirs      | []  [] [] [] []  [] []  []   [] []    [] [] [] [] |
+     xkeyboard-config   | []           []                 []    [] []       |
+                        +---------------------------------------------------+
+                          nl  nn or pa pl  ps pt pt_BR ro ru rw sk sl sq sr
+                          135 10  4  7 105  1 29  61   47 91  3 55 47  8 37
+
+                          sv  sw ta te tg th tr uk vi  wa zh_CN zh_HK zh_TW
+                        +---------------------------------------------------+
+     a2ps               | []              [] [] [] []                       | 27
+     aegis              |                          []                       |  9
+     ant-phone          | []                 []    []      []               |  9
+     anubis             | []                 [] [] []                       | 15
+     aspell             |                       [] []  []                   | 20
+     bash               | []                       []                       | 11
+     bfd                |                          []                       |  6
+     bibshelf           | []                       []      []               | 16
+     binutils           |                       [] []                       |  8
+     bison              | []                       []                       | 12
+     bison-runtime      | []              []    [] []      []          []   | 29
+     bluez-pin          | []              [] [] [] []  []  []          []   | 37
+     bombono-dvd        |                          []                       |  4
+     buzztard           |                          []                       |  7
+     cflow              |                       [] []      []               |  9
+     clisp              |                                                   | 10
+     coreutils          | []                    [] []      []               | 22
+     cpio               | []                 [] [] []      []          []   | 13
+     cppi               |                       [] []                       |  5
+     cpplib             | []                 [] [] []      []          []   | 13
+     cryptsetup         | []                       []                       |  7
+     dfarc              |                          []                       |  9
+     dialog             | []  []          []       []  []  []          []   | 30
+     dico               |                       []                          |  2
+     diffutils          | []                 [] [] []      []          []   | 30
+     dink               |                                                   |  4
+     doodle             | []                       []                       |  7
+     e2fsprogs          | []                 []    []                       | 11
+     enscript           | []                 [] [] []                       | 17
+     exif               | []                       []      []               | 16
+     fetchmail          |                    []    []      []               | 17
+     findutils          | []                 [] [] []      []               | 20
+     flex               | []                 []    []                  []   | 15
+     freedink           |                          []                       | 10
+     gas                |                    []                             |  4
+     gawk               | []                 []    []      []               | 18
+     gcal               | []                 []                             |  5
+     gcc                | []                 []            []               |  7
+     gettext-examples   | []                 [] [] []      []    []    []   | 34
+     gettext-runtime    | []                 [] [] []      []    []    []   | 30
+     gettext-tools      | []                 [] [] []      []          []   | 22
+     gip                | []                       []      []          []   | 22
+     gjay               |                          []                       |  3
+     gliv               | []                 []    []                       | 14
+     glunarclock        | []                       []  []  []          []   | 19
+     gnubiff            | []                       []                       |  4
+     gnucash            |                    () [] ()                  ()   |  9
+     gnuedu             |                          []                  []   |  7
+     gnulib             | []                    [] []      []               | 16
+     gnunet             |                          []                       |  1
+     gnunet-gtk         | []                 []    []                       |  5
+     gnutls             | []                       []      []               | 10
+     gold               |                          []                       |  4
+     gpe-aerial         | []                       []      []               | 18
+     gpe-beam           | []                       []      []               | 19
+     gpe-bluetooth      | []                       []      []               | 13
+     gpe-calendar       | []                       []  []  []               | 12
+     gpe-clock          | []                 []    []  []  []               | 28
+     gpe-conf           | []                       []  []  []               | 20
+     gpe-contacts       | []                       []      []               | 17
+     gpe-edit           | []                       []      []               | 12
+     gpe-filemanager    | []                       []  []  []               | 16
+     gpe-go             | []                 []    []  []  []               | 25
+     gpe-login          | []                       []      []               | 11
+     gpe-ownerinfo      | []                 []    []      []          []   | 25
+     gpe-package        | []                       []      []               | 13
+     gpe-sketchbook     | []                       []      []               | 20
+     gpe-su             | []                 []    []  []  []               | 30
+     gpe-taskmanager    | []                 []    []  []  []               | 29
+     gpe-timesheet      | []                 []    []      []          []   | 25
+     gpe-today          | []                 []    []  []  []          []   | 30
+     gpe-todo           | []                       []  []  []               | 17
+     gphoto2            | []                    [] []      []          []   | 24
+     gprof              | []                 []    []                       | 15
+     gpsdrive           | []                       []      []               | 11
+     gramadoir          | []                       []      []               | 11
+     grep               |                 []       []      []               | 10
+     grub               | []                       []      []               | 14
+     gsasl              | []                       []      []          []   | 14
+     gss                | []                       []      []               | 11
+     gst-plugins-bad    | []                 []    []      []               | 22
+     gst-plugins-base   | []                 [] [] []      []               | 24
+     gst-plugins-good   | []                 [] [] []      []               | 25
+     gst-plugins-ugly   | []                 [] [] []      []               | 29
+     gstreamer          | []                    [] []      []               | 22
+     gtick              |                       [] []      []               | 13
+     gtkam              | []                       []      []               | 20
+     gtkorphan          | []                       []      []               | 14
+     gtkspell           | []              [] [] [] []  []  []    []    []   | 45
+     gutenprint         | []                                                | 10
+     hello              | []              [] []    []      []          []   | 21
+     help2man           | []                       []                       |  7
+     hylafax            |                          []                       |  5
+     idutils            | []                 []    []      []               | 17
+     indent             | []                 [] [] []      []          []   | 30
+     iso_15924          |                 ()    [] ()      []          []   | 16
+     iso_3166           | []        []    () [] [] ()  []  []    []    ()   | 53
+     iso_3166_2         |                 ()    [] ()      []               |  9
+     iso_4217           | []              () [] [] ()      []    []         | 26
+     iso_639            | []     [] []    ()    [] ()  []  []    []    []   | 38
+     iso_639_3          |        []                ()                       |  8
+     jwhois             | []                 []    []      []          []   | 16
+     kbd                | []                 [] [] []      []               | 15
+     keytouch           | []                       []      []               | 16
+     keytouch-editor    | []                       []      []               | 14
+     keytouch-keyboa... | []                       []      []               | 14
+     klavaro            |                          []                       | 11
+     latrine            |                    []    []      []               | 10
+     ld                 | []                 []    []                  []   | 11
+     leafpad            | []                 [] [] []      []          []   | 33
+     libc               | []                 []    []      []          []   | 21
+     libexif            |                          []      ()               |  6
+     libextractor       |                          []                       |  1
+     libgnutls          | []                       []      []               |  9
+     libgpewidget       | []                       []      []               | 14
+     libgpg-error       | []                       []      []               |  9
+     libgphoto2         |                       [] []                       |  8
+     libgphoto2_port    | []                    [] []                  []   | 13
+     libgsasl           | []                       []      []               | 13
+     libiconv           | []                       []  []  []               | 21
+     libidn             | ()                       []      []               | 11
+     lifelines          | []                                                |  4
+     liferea            | []                 []            []               | 21
+     lilypond           |                          []                       |  7
+     linkdr             | []                 []    []      []          []   | 17
+     lordsawar          |                                                   |  1
+     lprng              |                          []                       |  3
+     lynx               | []                 [] [] []                       | 17
+     m4                 | []                       []      []          []   | 19
+     mailfromd          |                       [] []                       |  3
+     mailutils          |                          []                       |  5
+     make               | []                 []    []      []               | 21
+     man-db             | []                       []      []               |  8
+     man-db-manpages    |                                                   |  4
+     minicom            | []                       []                       | 16
+     mkisofs            |                          []      []               |  9
+     myserver           |                                                   |  0
+     nano               | []                       []      []          []   | 21
+     opcodes            | []                 []    []                       | 11
+     parted             | []                 [] [] []                  []   | 15
+     pies               |                       [] []                       |  3
+     popt               | []              [] []    []      []          []   | 27
+     psmisc             | []                       []                       | 11
+     pspp               |                                                   |  4
+     pwdutils           | []                       []                       |  6
+     radius             |                       [] []                       |  9
+     recode             | []                 []    []      []               | 28
+     rosegarden         | ()                                                |  0
+     rpm                | []                       []                  []   | 11
+     rush               |                       [] []                       |  4
+     sarg               |                                                   |  1
+     screem             |                          []                       |  3
+     scrollkeeper       | []                 [] [] []                  []   | 27
+     sed                | []                 []    []      []          []   | 30
+     sharutils          | []                 []    []      []          []   | 22
+     shishi             |                          []                       |  3
+     skencil            | []                       []                       |  7
+     solfege            | []                 []    []      []               | 16
+     solfege-manual     |                    []                             |  8
+     soundtracker       | []                 []    []                       |  9
+     sp                 |                    []                             |  3
+     sysstat            |                          []      []               | 15
+     tar                | []                 [] [] []      []          []   | 23
+     texinfo            | []                 []    []      []               | 16
+     tin                |                                                   |  4
+     unicode-han-tra... |                                                   |  0
+     unicode-transla... |                                                   |  2
+     util-linux-ng      | []                 [] [] []                       | 20
+     vice               | ()                 ()                             |  1
+     vmm                |                          []                       |  4
+     vorbis-tools       |                          []                       |  6
+     wastesedge         |                                                   |  2
+     wdiff              | []                       []                       |  7
+     wget               | []                 []    []      []          []   | 26
+     wyslij-po          |                       [] []                       |  8
+     xchat              | []              []    [] []      []          []   | 36
+     xdg-user-dirs      | []     []       [] [] [] []      []    []    []   | 60
+     xkeyboard-config   | []                 [] [] []                       | 25
+                        +---------------------------------------------------+
+       84 teams           sv  sw ta te tg th tr uk vi  wa zh_CN zh_HK zh_TW
+      178 domains         119  1  3  2  0 10 66 50 155 17  97     7    41    2610
 
    Some counters in the preceding matrix are higher than the number of
 visible blocks let us expect.  This is because a few extra PO files are
@@ -1350,30 +1296,32 @@ used for implementing regional variants of languages, or language
 dialects.
 
    For a PO file in the matrix above to be effective, the package to
-which it applies should also have been internationalized and distributed
-as such by its maintainer.  There might be an observable lag between the
-mere existence a PO file and its wide availability in a distribution.
+which it applies should also have been internationalized and
+distributed as such by its maintainer.  There might be an observable
+lag between the mere existence a PO file and its wide availability in a
+distribution.
 
-   If Jun 2014 seems to be old, you may fetch a more recent copy of this
-'ABOUT-NLS' file on most GNU archive sites.  The most up-to-date matrix
-with full percentage details can be found at
-'http://translationproject.org/extra/matrix.html'.
+   If May 2010 seems to be old, you may fetch a more recent copy of
+this `ABOUT-NLS' file on most GNU archive sites.  The most up-to-date
+matrix with full percentage details can be found at
+`http://translationproject.org/extra/matrix.html'.
 
-1.5 Using 'gettext' in new packages
+1.6 Using `gettext' in new packages
 ===================================
 
 If you are writing a freely available program and want to
-internationalize it you are welcome to use GNU 'gettext' in your
-package.  Of course you have to respect the GNU Lesser General Public
-License which covers the use of the GNU 'gettext' library.  This means
-in particular that even non-free programs can use 'libintl' as a shared
-library, whereas only free software can use 'libintl' as a static
-library or use modified versions of 'libintl'.
+internationalize it you are welcome to use GNU `gettext' in your
+package.  Of course you have to respect the GNU Library General Public
+License which covers the use of the GNU `gettext' library.  This means
+in particular that even non-free programs can use `libintl' as a shared
+library, whereas only free software can use `libintl' as a static
+library or use modified versions of `libintl'.
 
    Once the sources are changed appropriately and the setup can handle
-the use of 'gettext' the only thing missing are the translations.  The
+the use of `gettext' the only thing missing are the translations.  The
 Free Translation Project is also available for packages which are not
 developed inside the GNU project.  Therefore the information given above
 applies also for every other Free Software Project.  Contact
-'coordinator@translationproject.org' to make the '.pot' files available
+`coordinator@translationproject.org' to make the `.pot' files available
 to the translation teams.
+

--- a/config.rpath
+++ b/config.rpath
@@ -2,7 +2,7 @@
 # Output a system dependent set of variables, describing how to set the
 # run time search path of shared libraries in an executable.
 #
-#   Copyright 1996-2016 Free Software Foundation, Inc.
+#   Copyright 1996-2010 Free Software Foundation, Inc.
 #   Taken from GNU libtool, 2001
 #   Originally by Gordon Matzigkeit <gord@gnu.ai.mit.edu>, 1996
 #
@@ -25,7 +25,7 @@
 #   known workaround is to choose shorter directory names for the build
 #   directory and/or the installation directory.
 
-# All known linkers require a '.a' archive for static linking (except MSVC,
+# All known linkers require a `.a' archive for static linking (except MSVC,
 # which needs '.lib').
 libext=a
 shrext=.so
@@ -57,6 +57,13 @@ else
     aix*)
       wl='-Wl,'
       ;;
+    darwin*)
+      case $cc_basename in
+        xlc*)
+          wl='-Wl,'
+          ;;
+      esac
+      ;;
     mingw* | cygwin* | pw32* | os2* | cegcc*)
       ;;
     hpux9* | hpux10* | hpux11*)
@@ -65,7 +72,9 @@ else
     irix5* | irix6* | nonstopux*)
       wl='-Wl,'
       ;;
-    linux* | k*bsd*-gnu | kopensolaris*-gnu)
+    newsos6)
+      ;;
+    linux* | k*bsd*-gnu)
       case $cc_basename in
         ecc*)
           wl='-Wl,'
@@ -76,16 +85,10 @@ else
         lf95*)
           wl='-Wl,'
           ;;
-        nagfor*)
-          wl='-Wl,-Wl,,'
-          ;;
-        pgcc* | pgf77* | pgf90* | pgf95* | pgfortran*)
+        pgcc | pgf77 | pgf90)
           wl='-Wl,'
           ;;
         ccc*)
-          wl='-Wl,'
-          ;;
-        xl* | bgxl* | bgf* | mpixl*)
           wl='-Wl,'
           ;;
         como)
@@ -93,9 +96,6 @@ else
           ;;
         *)
           case `$CC -V 2>&1 | sed 5q` in
-            *Sun\ F* | *Sun*Fortran*)
-              wl=
-              ;;
             *Sun\ C*)
               wl='-Wl,'
               ;;
@@ -103,24 +103,13 @@ else
           ;;
       esac
       ;;
-    newsos6)
-      ;;
-    *nto* | *qnx*)
-      ;;
     osf3* | osf4* | osf5*)
       wl='-Wl,'
       ;;
     rdos*)
       ;;
     solaris*)
-      case $cc_basename in
-        f77* | f90* | f95* | sunf77* | sunf90* | sunf95*)
-          wl='-Qoption ld '
-          ;;
-        *)
-          wl='-Wl,'
-          ;;
-      esac
+      wl='-Wl,'
       ;;
     sunos4*)
       wl='-Qoption ld '
@@ -182,14 +171,15 @@ if test "$with_gnu_ld" = yes; then
       fi
       ;;
     amigaos*)
-      case "$host_cpu" in
-        powerpc)
-          ;;
-        m68k)
-          hardcode_libdir_flag_spec='-L$libdir'
-          hardcode_minus_L=yes
-          ;;
-      esac
+      hardcode_libdir_flag_spec='-L$libdir'
+      hardcode_minus_L=yes
+      # Samuel A. Falvo II <kc5tja@dolphin.openprojects.net> reports
+      # that the semantics of dynamic libraries on AmigaOS, at least up
+      # to version 4, is to share data among multiple programs linked
+      # with the same dynamic library.  Since this doesn't match the
+      # behavior of shared libraries on other platforms, we cannot use
+      # them.
+      ld_shlibs=no
       ;;
     beos*)
       if $LD --help 2>&1 | grep ': supported targets:.* elf' > /dev/null; then
@@ -208,13 +198,11 @@ if test "$with_gnu_ld" = yes; then
         ld_shlibs=no
       fi
       ;;
-    haiku*)
-      ;;
     interix[3-9]*)
       hardcode_direct=no
       hardcode_libdir_flag_spec='${wl}-rpath,$libdir'
       ;;
-    gnu* | linux* | tpf* | k*bsd*-gnu | kopensolaris*-gnu)
+    gnu* | linux* | k*bsd*-gnu)
       if $LD --help 2>&1 | grep ': supported targets:.* elf' > /dev/null; then
         :
       else
@@ -337,14 +325,10 @@ else
       fi
       ;;
     amigaos*)
-      case "$host_cpu" in
-        powerpc)
-          ;;
-        m68k)
-          hardcode_libdir_flag_spec='-L$libdir'
-          hardcode_minus_L=yes
-          ;;
-      esac
+      hardcode_libdir_flag_spec='-L$libdir'
+      hardcode_minus_L=yes
+      # see comment about different semantics on the GNU ld section
+      ld_shlibs=no
       ;;
     bsdi[45]*)
       ;;
@@ -358,16 +342,29 @@ else
       ;;
     darwin* | rhapsody*)
       hardcode_direct=no
-      if { case $cc_basename in ifort*) true;; *) test "$GCC" = yes;; esac; }; then
+      if test "$GCC" = yes ; then
         :
       else
-        ld_shlibs=no
+        case $cc_basename in
+          xlc*)
+            ;;
+          *)
+            ld_shlibs=no
+            ;;
+        esac
       fi
       ;;
     dgux*)
       hardcode_libdir_flag_spec='-L$libdir'
       ;;
-    freebsd2.[01]*)
+    freebsd1*)
+      ld_shlibs=no
+      ;;
+    freebsd2.2*)
+      hardcode_libdir_flag_spec='-R$libdir'
+      hardcode_direct=yes
+      ;;
+    freebsd2*)
       hardcode_direct=yes
       hardcode_minus_L=yes
       ;;
@@ -422,8 +419,6 @@ else
       hardcode_direct=yes
       hardcode_libdir_flag_spec='${wl}-rpath ${wl}$libdir'
       hardcode_libdir_separator=:
-      ;;
-    *nto* | *qnx*)
       ;;
     openbsd*)
       if test -f /usr/libexec/ld.so; then
@@ -520,12 +515,7 @@ case "$host_os" in
     library_names_spec='$libname$shrext'
     ;;
   amigaos*)
-    case "$host_cpu" in
-      powerpc*)
-        library_names_spec='$libname$shrext' ;;
-      m68k)
-        library_names_spec='$libname.a' ;;
-    esac
+    library_names_spec='$libname.a'
     ;;
   beos*)
     library_names_spec='$libname$shrext'
@@ -544,16 +534,17 @@ case "$host_os" in
   dgux*)
     library_names_spec='$libname$shrext'
     ;;
-  freebsd[23].*)
-    library_names_spec='$libname$shrext$versuffix'
+  freebsd1*)
     ;;
   freebsd* | dragonfly*)
-    library_names_spec='$libname$shrext'
+    case "$host_os" in
+      freebsd[123]*)
+        library_names_spec='$libname$shrext$versuffix' ;;
+      *)
+        library_names_spec='$libname$shrext' ;;
+    esac
     ;;
   gnu*)
-    library_names_spec='$libname$shrext'
-    ;;
-  haiku*)
     library_names_spec='$libname$shrext'
     ;;
   hpux9* | hpux10* | hpux11*)
@@ -591,7 +582,7 @@ case "$host_os" in
     ;;
   linux*oldld* | linux*aout* | linux*coff*)
     ;;
-  linux* | k*bsd*-gnu | kopensolaris*-gnu)
+  linux* | k*bsd*-gnu)
     library_names_spec='$libname$shrext'
     ;;
   knetbsd*-gnu)
@@ -603,7 +594,7 @@ case "$host_os" in
   newsos6)
     library_names_spec='$libname$shrext'
     ;;
-  *nto* | *qnx*)
+  nto-qnx*)
     library_names_spec='$libname$shrext'
     ;;
   openbsd*)
@@ -632,9 +623,6 @@ case "$host_os" in
     library_names_spec='$libname$shrext'
     ;;
   sysv5* | sco3.2v5* | sco5v6* | unixware* | OpenUNIX* | sysv4*uw2*)
-    library_names_spec='$libname$shrext'
-    ;;
-  tpf*)
     library_names_spec='$libname$shrext'
     ;;
   uts4*)

--- a/configure.ac
+++ b/configure.ac
@@ -35,8 +35,8 @@ gl_VISIBILITY
 # Checks for library functions.
 
 dnl internationalization macros
+AM_GNU_GETTEXT_VERSION(0.18)
 AM_GNU_GETTEXT([external])
-AM_GNU_GETTEXT_REQUIRE_VERSION(0.17)
 
 AC_ARG_WITH(warnings,[  --with-warnings         compile with warning messages],[
 	AC_DEFINE(HUNSPELL_WARNING_ON,1,"Define if you need warning messages")

--- a/m4/gettext.m4
+++ b/m4/gettext.m4
@@ -1,16 +1,16 @@
-# gettext.m4 serial 68 (gettext-0.19.8)
-dnl Copyright (C) 1995-2014, 2016 Free Software Foundation, Inc.
+# gettext.m4 serial 63 (gettext-0.18)
+dnl Copyright (C) 1995-2010 Free Software Foundation, Inc.
 dnl This file is free software; the Free Software Foundation
 dnl gives unlimited permission to copy and/or distribute it,
 dnl with or without modifications, as long as this notice is preserved.
 dnl
-dnl This file can be used in projects which are not available under
+dnl This file can can be used in projects which are not available under
 dnl the GNU General Public License or the GNU Library General Public
 dnl License but which still want to provide support for the GNU gettext
 dnl functionality.
 dnl Please note that the actual code of the GNU gettext library is covered
 dnl by the GNU Library General Public License, and the rest of the GNU
-dnl gettext package is covered by the GNU General Public License.
+dnl gettext package package is covered by the GNU General Public License.
 dnl They are *not* in the public domain.
 
 dnl Authors:
@@ -35,7 +35,7 @@ dnl    will be ignored.  If NEEDSYMBOL is specified and is
 dnl    'need-formatstring-macros', then GNU gettext implementations that don't
 dnl    support the ISO C 99 <inttypes.h> formatstring macros will be ignored.
 dnl INTLDIR is used to find the intl libraries.  If empty,
-dnl    the value '$(top_builddir)/intl/' is used.
+dnl    the value `$(top_builddir)/intl/' is used.
 dnl
 dnl The result of the configuration is one of three cases:
 dnl 1) GNU gettext, as included in the intl subdirectory, will be compiled
@@ -97,7 +97,7 @@ AC_DEFUN([AM_GNU_GETTEXT],
     AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
   ])
 
-  dnl Sometimes, on Mac OS X, libintl requires linking with CoreFoundation.
+  dnl Sometimes, on MacOS X, libintl requires linking with CoreFoundation.
   gt_INTL_MACOSX
 
   dnl Set USE_NLS.
@@ -157,23 +157,12 @@ changequote([,])dnl
         fi
 
         AC_CACHE_CHECK([for GNU gettext in libc], [$gt_func_gnugettext_libc],
-         [AC_LINK_IFELSE(
-            [AC_LANG_PROGRAM(
-               [[
-#include <libintl.h>
-#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
-extern int _nl_msg_cat_cntr;
-extern int *_nl_domain_bindings;
-#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_domain_bindings)
-#else
-#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
-#endif
+         [AC_TRY_LINK([#include <libintl.h>
 $gt_revision_test_code
-               ]],
-               [[
-bindtextdomain ("", "");
-return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
-               ]])],
+extern int _nl_msg_cat_cntr;
+extern int *_nl_domain_bindings;],
+            [bindtextdomain ("", "");
+return * gettext ("")$gt_expression_test_code + _nl_msg_cat_cntr + *_nl_domain_bindings],
             [eval "$gt_func_gnugettext_libc=yes"],
             [eval "$gt_func_gnugettext_libc=no"])])
 
@@ -194,57 +183,35 @@ return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
             gt_save_LIBS="$LIBS"
             LIBS="$LIBS $LIBINTL"
             dnl Now see whether libintl exists and does not depend on libiconv.
-            AC_LINK_IFELSE(
-              [AC_LANG_PROGRAM(
-                 [[
-#include <libintl.h>
-#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
+            AC_TRY_LINK([#include <libintl.h>
+$gt_revision_test_code
 extern int _nl_msg_cat_cntr;
 extern
 #ifdef __cplusplus
 "C"
 #endif
-const char *_nl_expand_alias (const char *);
-#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
-#else
-#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
-#endif
-$gt_revision_test_code
-                 ]],
-                 [[
-bindtextdomain ("", "");
-return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
-                 ]])],
+const char *_nl_expand_alias (const char *);],
+              [bindtextdomain ("", "");
+return * gettext ("")$gt_expression_test_code + _nl_msg_cat_cntr + *_nl_expand_alias ("")],
               [eval "$gt_func_gnugettext_libintl=yes"],
               [eval "$gt_func_gnugettext_libintl=no"])
             dnl Now see whether libintl exists and depends on libiconv.
             if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" != yes; } && test -n "$LIBICONV"; then
               LIBS="$LIBS $LIBICONV"
-              AC_LINK_IFELSE(
-                [AC_LANG_PROGRAM(
-                   [[
-#include <libintl.h>
-#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
+              AC_TRY_LINK([#include <libintl.h>
+$gt_revision_test_code
 extern int _nl_msg_cat_cntr;
 extern
 #ifdef __cplusplus
 "C"
 #endif
-const char *_nl_expand_alias (const char *);
-#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
-#else
-#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
-#endif
-$gt_revision_test_code
-                   ]],
-                   [[
-bindtextdomain ("", "");
-return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
-                   ]])],
-                [LIBINTL="$LIBINTL $LIBICONV"
-                 LTLIBINTL="$LTLIBINTL $LTLIBICONV"
-                 eval "$gt_func_gnugettext_libintl=yes"
-                ])
+const char *_nl_expand_alias (const char *);],
+                [bindtextdomain ("", "");
+return * gettext ("")$gt_expression_test_code + _nl_msg_cat_cntr + *_nl_expand_alias ("")],
+               [LIBINTL="$LIBINTL $LIBICONV"
+                LTLIBINTL="$LTLIBINTL $LTLIBICONV"
+                eval "$gt_func_gnugettext_libintl=yes"
+               ])
             fi
             CPPFLAGS="$gt_save_CPPFLAGS"
             LIBS="$gt_save_LIBS"])
@@ -414,7 +381,3 @@ AC_DEFUN([AM_GNU_GETTEXT_NEED],
 
 dnl Usage: AM_GNU_GETTEXT_VERSION([gettext-version])
 AC_DEFUN([AM_GNU_GETTEXT_VERSION], [])
-
-
-dnl Usage: AM_GNU_GETTEXT_REQUIRE_VERSION([gettext-version])
-AC_DEFUN([AM_GNU_GETTEXT_REQUIRE_VERSION], [])

--- a/m4/po.m4
+++ b/m4/po.m4
@@ -1,36 +1,35 @@
-# po.m4 serial 24 (gettext-0.19)
-dnl Copyright (C) 1995-2014, 2016 Free Software Foundation, Inc.
+# po.m4 serial 17 (gettext-0.18)
+dnl Copyright (C) 1995-2010 Free Software Foundation, Inc.
 dnl This file is free software; the Free Software Foundation
 dnl gives unlimited permission to copy and/or distribute it,
 dnl with or without modifications, as long as this notice is preserved.
 dnl
-dnl This file can be used in projects which are not available under
+dnl This file can can be used in projects which are not available under
 dnl the GNU General Public License or the GNU Library General Public
 dnl License but which still want to provide support for the GNU gettext
 dnl functionality.
 dnl Please note that the actual code of the GNU gettext library is covered
 dnl by the GNU Library General Public License, and the rest of the GNU
-dnl gettext package is covered by the GNU General Public License.
+dnl gettext package package is covered by the GNU General Public License.
 dnl They are *not* in the public domain.
 
 dnl Authors:
 dnl   Ulrich Drepper <drepper@cygnus.com>, 1995-2000.
 dnl   Bruno Haible <haible@clisp.cons.org>, 2000-2003.
 
-AC_PREREQ([2.60])
+AC_PREREQ([2.50])
 
 dnl Checks for all prerequisites of the po subdirectory.
 AC_DEFUN([AM_PO_SUBDIRS],
 [
   AC_REQUIRE([AC_PROG_MAKE_SET])dnl
   AC_REQUIRE([AC_PROG_INSTALL])dnl
-  AC_REQUIRE([AC_PROG_MKDIR_P])dnl
-  AC_REQUIRE([AC_PROG_SED])dnl
+  AC_REQUIRE([AM_PROG_MKDIR_P])dnl defined by automake
   AC_REQUIRE([AM_NLS])dnl
 
   dnl Release version of the gettext macros. This is used to ensure that
   dnl the gettext macros and po/Makefile.in.in are in sync.
-  AC_SUBST([GETTEXT_MACRO_VERSION], [0.19])
+  AC_SUBST([GETTEXT_MACRO_VERSION], [0.18])
 
   dnl Perform the following tests also if --disable-nls has been given,
   dnl because they are needed for "make dist" to work.
@@ -103,7 +102,7 @@ changequote([,])dnl
       case "$ac_file" in */Makefile.in)
         # Adjust a relative srcdir.
         ac_dir=`echo "$ac_file"|sed 's%/[^/][^/]*$%%'`
-        ac_dir_suffix=/`echo "$ac_dir"|sed 's%^\./%%'`
+        ac_dir_suffix="/`echo "$ac_dir"|sed 's%^\./%%'`"
         ac_dots=`echo "$ac_dir_suffix"|sed 's%/[^/]*%../%g'`
         # In autoconf-2.13 it is called $ac_given_srcdir.
         # In autoconf-2.50 it is called $srcdir.
@@ -119,8 +118,7 @@ changequote([,])dnl
         if test -f "$ac_given_srcdir/$ac_dir/POTFILES.in"; then
           rm -f "$ac_dir/POTFILES"
           test -n "$as_me" && echo "$as_me: creating $ac_dir/POTFILES" || echo "creating $ac_dir/POTFILES"
-          gt_tab=`printf '\t'`
-          cat "$ac_given_srcdir/$ac_dir/POTFILES.in" | sed -e "/^#/d" -e "/^[ ${gt_tab}]*\$/d" -e "s,.*,     $top_srcdir/& \\\\," | sed -e "\$s/\(.*\) \\\\/\1/" > "$ac_dir/POTFILES"
+          cat "$ac_given_srcdir/$ac_dir/POTFILES.in" | sed -e "/^#/d" -e "/^[ 	]*\$/d" -e "s,.*,     $top_srcdir/& \\\\," | sed -e "\$s/\(.*\) \\\\/\1/" > "$ac_dir/POTFILES"
           POMAKEFILEDEPS="POTFILES.in"
           # ALL_LINGUAS, POFILES, UPDATEPOFILES, DUMMYPOFILES, GMOFILES depend
           # on $ac_dir but don't depend on user-specified configuration
@@ -131,12 +129,12 @@ changequote([,])dnl
               test -n "$as_me" && echo "$as_me: setting ALL_LINGUAS in configure.in is obsolete" || echo "setting ALL_LINGUAS in configure.in is obsolete"
             fi
             ALL_LINGUAS_=`sed -e "/^#/d" -e "s/#.*//" "$ac_given_srcdir/$ac_dir/LINGUAS"`
-            # Hide the ALL_LINGUAS assignment from automake < 1.5.
+            # Hide the ALL_LINGUAS assigment from automake < 1.5.
             eval 'ALL_LINGUAS''=$ALL_LINGUAS_'
             POMAKEFILEDEPS="$POMAKEFILEDEPS LINGUAS"
           else
             # The set of available languages was given in configure.in.
-            # Hide the ALL_LINGUAS assignment from automake < 1.5.
+            # Hide the ALL_LINGUAS assigment from automake < 1.5.
             eval 'ALL_LINGUAS''=$OBSOLETE_ALL_LINGUAS'
           fi
           # Compute POFILES
@@ -228,7 +226,7 @@ AC_DEFUN([AM_POSTPROCESS_PO_MAKEFILE],
 changequote(,)dnl
   # Adjust a relative srcdir.
   ac_dir=`echo "$ac_file"|sed 's%/[^/][^/]*$%%'`
-  ac_dir_suffix=/`echo "$ac_dir"|sed 's%^\./%%'`
+  ac_dir_suffix="/`echo "$ac_dir"|sed 's%^\./%%'`"
   ac_dots=`echo "$ac_dir_suffix"|sed 's%/[^/]*%../%g'`
   # In autoconf-2.13 it is called $ac_given_srcdir.
   # In autoconf-2.50 it is called $srcdir.
@@ -256,7 +254,6 @@ EOT
   fi
 
   # A sed script that extracts the value of VARIABLE from a Makefile.
-  tab=`printf '\t'`
   sed_x_variable='
 # Test if the hold space is empty.
 x
@@ -264,9 +261,9 @@ s/P/P/
 x
 ta
 # Yes it was empty. Look if we have the expected variable definition.
-/^['"${tab}"' ]*VARIABLE['"${tab}"' ]*=/{
+/^[	 ]*VARIABLE[	 ]*=/{
   # Seen the first line of the variable definition.
-  s/^['"${tab}"' ]*VARIABLE['"${tab}"' ]*=//
+  s/^[	 ]*VARIABLE[	 ]*=//
   ba
 }
 bd
@@ -318,7 +315,7 @@ changequote([,])dnl
     sed_x_LINGUAS=`$gt_echo "$sed_x_variable" | sed -e '/^ *#/d' -e 's/VARIABLE/LINGUAS/g'`
     ALL_LINGUAS_=`sed -n -e "$sed_x_LINGUAS" < "$ac_file"`
   fi
-  # Hide the ALL_LINGUAS assignment from automake < 1.5.
+  # Hide the ALL_LINGUAS assigment from automake < 1.5.
   eval 'ALL_LINGUAS''=$ALL_LINGUAS_'
   # Compute POFILES
   # as      $(foreach lang, $(ALL_LINGUAS), $(srcdir)/$(lang).po)
@@ -408,15 +405,14 @@ changequote([,])dnl
   fi
 
   sed -e "s|@POTFILES_DEPS@|$POTFILES_DEPS|g" -e "s|@POFILES@|$POFILES|g" -e "s|@UPDATEPOFILES@|$UPDATEPOFILES|g" -e "s|@DUMMYPOFILES@|$DUMMYPOFILES|g" -e "s|@GMOFILES@|$GMOFILES|g" -e "s|@PROPERTIESFILES@|$PROPERTIESFILES|g" -e "s|@CLASSFILES@|$CLASSFILES|g" -e "s|@QMFILES@|$QMFILES|g" -e "s|@MSGFILES@|$MSGFILES|g" -e "s|@RESOURCESDLLFILES@|$RESOURCESDLLFILES|g" -e "s|@CATALOGS@|$CATALOGS|g" -e "s|@JAVACATALOGS@|$JAVACATALOGS|g" -e "s|@QTCATALOGS@|$QTCATALOGS|g" -e "s|@TCLCATALOGS@|$TCLCATALOGS|g" -e "s|@CSHARPCATALOGS@|$CSHARPCATALOGS|g" -e 's,^#distdir:,distdir:,' < "$ac_file" > "$ac_file.tmp"
-  tab=`printf '\t'`
   if grep -l '@TCLCATALOGS@' "$ac_file" > /dev/null; then
     # Add dependencies that cannot be formulated as a simple suffix rule.
     for lang in $ALL_LINGUAS; do
       frobbedlang=`echo $lang | sed -e 's/\..*$//' -e 'y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/'`
       cat >> "$ac_file.tmp" <<EOF
 $frobbedlang.msg: $lang.po
-${tab}@echo "\$(MSGFMT) -c --tcl -d \$(srcdir) -l $lang $srcdirpre$lang.po"; \
-${tab}\$(MSGFMT) -c --tcl -d "\$(srcdir)" -l $lang $srcdirpre$lang.po || { rm -f "\$(srcdir)/$frobbedlang.msg"; exit 1; }
+	@echo "\$(MSGFMT) -c --tcl -d \$(srcdir) -l $lang $srcdirpre$lang.po"; \
+	\$(MSGFMT) -c --tcl -d "\$(srcdir)" -l $lang $srcdirpre$lang.po || { rm -f "\$(srcdir)/$frobbedlang.msg"; exit 1; }
 EOF
     done
   fi
@@ -426,8 +422,8 @@ EOF
       frobbedlang=`echo $lang | sed -e 's/_/-/g' -e 's/^sr-CS/sr-SP/' -e 's/@latin$/-Latn/' -e 's/@cyrillic$/-Cyrl/' -e 's/^sr-SP$/sr-SP-Latn/' -e 's/^uz-UZ$/uz-UZ-Latn/'`
       cat >> "$ac_file.tmp" <<EOF
 $frobbedlang/\$(DOMAIN).resources.dll: $lang.po
-${tab}@echo "\$(MSGFMT) -c --csharp -d \$(srcdir) -l $lang $srcdirpre$lang.po -r \$(DOMAIN)"; \
-${tab}\$(MSGFMT) -c --csharp -d "\$(srcdir)" -l $lang $srcdirpre$lang.po -r "\$(DOMAIN)" || { rm -f "\$(srcdir)/$frobbedlang.msg"; exit 1; }
+	@echo "\$(MSGFMT) -c --csharp -d \$(srcdir) -l $lang $srcdirpre$lang.po -r \$(DOMAIN)"; \
+	\$(MSGFMT) -c --csharp -d "\$(srcdir)" -l $lang $srcdirpre$lang.po -r "\$(DOMAIN)" || { rm -f "\$(srcdir)/$frobbedlang.msg"; exit 1; }
 EOF
     done
   fi

--- a/po/Makefile.in.in
+++ b/po/Makefile.in.in
@@ -1,19 +1,20 @@
 # Makefile for PO directory in any package using GNU gettext.
 # Copyright (C) 1995-1997, 2000-2007, 2009-2010 by Ulrich Drepper <drepper@gnu.ai.mit.edu>
 #
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# This file can be copied and used freely without restrictions.  It can
+# be used in projects which are not available under the GNU General Public
+# License but which still want to provide support for the GNU gettext
+# functionality.
+# Please note that the actual code of GNU gettext is covered by the GNU
+# General Public License and is *not* in the public domain.
 #
-# Origin: gettext-0.19.8
-GETTEXT_MACRO_VERSION = 0.19
+# Origin: gettext-0.18
+GETTEXT_MACRO_VERSION = 0.18
 
 PACKAGE = @PACKAGE@
 VERSION = @VERSION@
 PACKAGE_BUGREPORT = @PACKAGE_BUGREPORT@
 
-SED = @SED@
 SHELL = /bin/sh
 @SET_MAKE@
 
@@ -42,11 +43,6 @@ mkinstalldirs = $(SHELL) @install_sh@ -d
 install_sh = $(SHELL) @install_sh@
 MKDIR_P = @MKDIR_P@
 mkdir_p = @mkdir_p@
-
-# When building gettext-tools, we prefer to use the built programs
-# rather than installed programs.  However, we can't do that when we
-# are cross compiling.
-CROSS_COMPILING = @CROSS_COMPILING@
 
 GMSGFMT_ = @GMSGFMT@
 GMSGFMT_no = @GMSGFMT@
@@ -80,16 +76,6 @@ POTFILES = \
 
 CATALOGS = @CATALOGS@
 
-POFILESDEPS_ = $(srcdir)/$(DOMAIN).pot
-POFILESDEPS_yes = $(POFILESDEPS_)
-POFILESDEPS_no =
-POFILESDEPS = $(POFILESDEPS_$(PO_DEPENDS_ON_POT))
-
-DISTFILESDEPS_ = update-po
-DISTFILESDEPS_yes = $(DISTFILESDEPS_)
-DISTFILESDEPS_no =
-DISTFILESDEPS = $(DISTFILESDEPS_$(DIST_DEPENDS_ON_UPDATE_PO))
-
 # Makevars gets inserted here. (Don't remove this line!)
 
 .SUFFIXES:
@@ -110,14 +96,14 @@ DISTFILESDEPS = $(DISTFILESDEPS_$(DIST_DEPENDS_ON_UPDATE_PO))
 	mv t-$@ $@
 
 
-all: all-@USE_NLS@
+all: check-macro-version all-@USE_NLS@
 
 all-yes: stamp-po
 all-no:
 
 # Ensure that the gettext macros and this Makefile.in.in are in sync.
-CHECK_MACRO_VERSION = \
-	test "$(GETTEXT_MACRO_VERSION)" = "@GETTEXT_MACRO_VERSION@" \
+check-macro-version:
+	@test "$(GETTEXT_MACRO_VERSION)" = "@GETTEXT_MACRO_VERSION@" \
 	  || { echo "*** error: gettext infrastructure mismatch: using a Makefile.in.in from gettext version $(GETTEXT_MACRO_VERSION) but the autoconf macros are from gettext version @GETTEXT_MACRO_VERSION@" 1>&2; \
 	       exit 1; \
 	     }
@@ -137,7 +123,6 @@ CHECK_MACRO_VERSION = \
 # $(POFILES) has been designed to not touch files that don't need to be
 # changed.
 stamp-po: $(srcdir)/$(DOMAIN).pot
-	@$(CHECK_MACRO_VERSION)
 	test ! -f $(srcdir)/$(DOMAIN).pot || \
 	  test -z "$(GMOFILES)" || $(MAKE) $(GMOFILES)
 	@test ! -f $(srcdir)/$(DOMAIN).pot || { \
@@ -152,29 +137,11 @@ stamp-po: $(srcdir)/$(DOMAIN).pot
 
 # This target rebuilds $(DOMAIN).pot; it is an expensive operation.
 # Note that $(DOMAIN).pot is not touched if it doesn't need to be changed.
-# The determination of whether the package xyz is a GNU one is based on the
-# heuristic whether some file in the top level directory mentions "GNU xyz".
-# If GNU 'find' is available, we avoid grepping through monster files.
 $(DOMAIN).pot-update: $(POTFILES) $(srcdir)/POTFILES.in remove-potcdate.sed
-	package_gnu="$(PACKAGE_GNU)"; \
-	test -n "$$package_gnu" || { \
-	  if { if (LC_ALL=C find --version) 2>/dev/null | grep GNU >/dev/null; then \
-		 LC_ALL=C find -L $(top_srcdir) -maxdepth 1 -type f \
-			       -size -10000000c -exec grep 'GNU @PACKAGE@' \
-			       /dev/null '{}' ';' 2>/dev/null; \
-	       else \
-		 LC_ALL=C grep 'GNU @PACKAGE@' $(top_srcdir)/* 2>/dev/null; \
-	       fi; \
-	     } | grep -v 'libtool:' >/dev/null; then \
-	     package_gnu=yes; \
-	   else \
-	     package_gnu=no; \
-	   fi; \
-	}; \
-	if test "$$package_gnu" = "yes"; then \
-	  package_prefix='GNU '; \
+	if LC_ALL=C grep 'GNU @PACKAGE@' $(top_srcdir)/* 2>/dev/null | grep -v 'libtool:' >/dev/null; then \
+	  package_gnu='GNU '; \
 	else \
-	  package_prefix=''; \
+	  package_gnu=''; \
 	fi; \
 	if test -n '$(MSGID_BUGS_ADDRESS)' || test '$(PACKAGE_BUGREPORT)' = '@'PACKAGE_BUGREPORT'@'; then \
 	  msgid_bugs_address='$(MSGID_BUGS_ADDRESS)'; \
@@ -194,17 +161,12 @@ $(DOMAIN).pot-update: $(POTFILES) $(srcdir)/POTFILES.in remove-potcdate.sed
 	      --add-comments=TRANSLATORS: $(XGETTEXT_OPTIONS) @XGETTEXT_EXTRA_OPTIONS@ \
 	      --files-from=$(srcdir)/POTFILES.in \
 	      --copyright-holder='$(COPYRIGHT_HOLDER)' \
-	      --package-name="$${package_prefix}@PACKAGE@" \
+	      --package-name="$${package_gnu}@PACKAGE@" \
 	      --package-version='@VERSION@' \
 	      --msgid-bugs-address="$$msgid_bugs_address" \
 	    ;; \
 	esac
 	test ! -f $(DOMAIN).po || { \
-	  if test -f $(srcdir)/$(DOMAIN).pot-header; then \
-	    sed -e '1,/^#$$/d' < $(DOMAIN).po > $(DOMAIN).1po && \
-	    cat $(srcdir)/$(DOMAIN).pot-header $(DOMAIN).1po > $(DOMAIN).po; \
-	    rm -f $(DOMAIN).1po; \
-	  fi; \
 	  if test -f $(srcdir)/$(DOMAIN).pot; then \
 	    sed -f remove-potcdate.sed < $(srcdir)/$(DOMAIN).pot > $(DOMAIN).1po && \
 	    sed -f remove-potcdate.sed < $(DOMAIN).po > $(DOMAIN).2po && \
@@ -227,14 +189,13 @@ $(srcdir)/$(DOMAIN).pot:
 
 # This target rebuilds a PO file if $(DOMAIN).pot has changed.
 # Note that a PO file is not touched if it doesn't need to be changed.
-$(POFILES): $(POFILESDEPS)
+$(POFILES): $(srcdir)/$(DOMAIN).pot
 	@lang=`echo $@ | sed -e 's,.*/,,' -e 's/\.po$$//'`; \
 	if test -f "$(srcdir)/$${lang}.po"; then \
-	  test -f $(srcdir)/$(DOMAIN).pot || $(MAKE) $(srcdir)/$(DOMAIN).pot; \
 	  test "$(srcdir)" = . && cdcmd="" || cdcmd="cd $(srcdir) && "; \
 	  echo "$${cdcmd}$(MSGMERGE_UPDATE) $(MSGMERGE_OPTIONS) --lang=$${lang} $${lang}.po $(DOMAIN).pot"; \
 	  cd $(srcdir) \
-	    && { case `$(MSGMERGE) --version | sed 1q | sed -e 's,^[^0-9]*,,'` in \
+	    && { case `$(MSGMERGE_UPDATE) --version | sed 1q | sed -e 's,^[^0-9]*,,'` in \
 	           '' | 0.[0-9] | 0.[0-9].* | 0.1[0-7] | 0.1[0-7].*) \
 	             $(MSGMERGE_UPDATE) $(MSGMERGE_OPTIONS) $${lang}.po $(DOMAIN).pot;; \
 	           *) \
@@ -391,7 +352,7 @@ maintainer-clean: distclean
 
 distdir = $(top_builddir)/$(PACKAGE)-$(VERSION)/$(subdir)
 dist distdir:
-	test -z "$(DISTFILESDEPS)" || $(MAKE) $(DISTFILESDEPS)
+	$(MAKE) update-po
 	@$(MAKE) dist2
 # This is a separate target because 'update-po' must be executed before.
 dist2: stamp-po $(DISTFILES)
@@ -435,7 +396,7 @@ update-po: Makefile
 
 .nop.po-update:
 	@lang=`echo $@ | sed -e 's/\.po-update$$//'`; \
-	if test "$(PACKAGE)" = "gettext-tools" && test "$(CROSS_COMPILING)" != "yes"; then PATH=`pwd`/../src:$$PATH; fi; \
+	if test "$(PACKAGE)" = "gettext-tools"; then PATH=`pwd`/../src:$$PATH; fi; \
 	tmpdir=`pwd`; \
 	echo "$$lang:"; \
 	test "$(srcdir)" = . && cdcmd="" || cdcmd="cd $(srcdir) && "; \

--- a/po/Rules-quot
+++ b/po/Rules-quot
@@ -1,4 +1,3 @@
-# This file, Rules-quot, can be copied and used freely without restrictions.
 # Special Makefile rules for English message catalogs with quotation marks.
 
 DISTFILES.common.extra1 = quot.sed boldquot.sed en@quot.header en@boldquot.header insert-header.sin Rules-quot
@@ -15,23 +14,13 @@ en@boldquot.po-update: en@boldquot.po-update-en
 
 .insert-header.po-update-en:
 	@lang=`echo $@ | sed -e 's/\.po-update-en$$//'`; \
-	if test "$(PACKAGE)" = "gettext-tools" && test "$(CROSS_COMPILING)" != "yes"; then PATH=`pwd`/../src:$$PATH; GETTEXTLIBDIR=`cd $(top_srcdir)/src && pwd`; export GETTEXTLIBDIR; fi; \
+	if test "$(PACKAGE)" = "gettext"; then PATH=`pwd`/../src:$$PATH; GETTEXTLIBDIR=`cd $(top_srcdir)/src && pwd`; export GETTEXTLIBDIR; fi; \
 	tmpdir=`pwd`; \
 	echo "$$lang:"; \
 	ll=`echo $$lang | sed -e 's/@.*//'`; \
 	LC_ALL=C; export LC_ALL; \
 	cd $(srcdir); \
-	if $(MSGINIT) $(MSGINIT_OPTIONS) -i $(DOMAIN).pot --no-translator -l $$lang -o - 2>/dev/null \
-	   | $(SED) -f $$tmpdir/$$lang.insert-header | $(MSGCONV) -t UTF-8 | \
-	   { case `$(MSGFILTER) --version | sed 1q | sed -e 's,^[^0-9]*,,'` in \
-	     '' | 0.[0-9] | 0.[0-9].* | 0.1[0-8] | 0.1[0-8].*) \
-	       $(MSGFILTER) $(SED) -f `echo $$lang | sed -e 's/.*@//'`.sed \
-	       ;; \
-	     *) \
-	       $(MSGFILTER) `echo $$lang | sed -e 's/.*@//'` \
-	       ;; \
-	     esac } 2>/dev/null > $$tmpdir/$$lang.new.po \
-	     ; then \
+	if $(MSGINIT) -i $(DOMAIN).pot --no-translator -l $$lang -o - 2>/dev/null | sed -f $$tmpdir/$$lang.insert-header | $(MSGCONV) -t UTF-8 | $(MSGFILTER) sed -f `echo $$lang | sed -e 's/.*@//'`.sed 2>/dev/null > $$tmpdir/$$lang.new.po; then \
 	  if cmp $$lang.po $$tmpdir/$$lang.new.po >/dev/null 2>&1; then \
 	    rm -f $$tmpdir/$$lang.new.po; \
 	  else \


### PR DESCRIPTION
because autoreconf without AM_GNU_GETTEXT_VERSION isn't working with
appveyor macOS brew (gettext 0.18.2)

and bump to 0.18 while I'm at it