### PR TITLE
Allow to call Hunspell constructor with null/empty paths

### DIFF
--- a/src/hunspell/filemgr.cxx
+++ b/src/hunspell/filemgr.cxx
@@ -83,6 +83,8 @@ int FileMgr::fail(const char* err, const char* par) {
 FileMgr::FileMgr(const char* file, const char* key) : hin(NULL), linenum(0) {
   in[0] = '\0';
 
+  if (!file || !strlen(file))
+    return;
   myopen(fin, file, std::ios_base::in);
   if (!fin.is_open()) {
     // check hzipped file
@@ -103,7 +105,7 @@ bool FileMgr::getline(std::string& dest) {
   ++linenum;
   if (fin.is_open()) {
     ret = static_cast<bool>(std::getline(fin, dest));
-  } else if (hin->is_open()) {
+  } else if (hin && hin->is_open()) {
     ret = hin->getline(dest);
   }
   if (!ret) {


### PR DESCRIPTION
It could be used as an object for custom dictionary with words added via application interface.
Currently hunspell throws an exception with nullptr paths and prints a error to stderr when a path is empty.