### PR TITLE
Fixes missplaced backquote at "--with-ui option"

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ For dictionary development, use the `--with-warnings` option of
 configure.
 
 For interactive user interface of Hunspell executable, use the
-`--with-ui option`.
+`--with-ui` option.
 
 Optional developer packages:
 


### PR DESCRIPTION
Way README was formatted will make people think "option" is part of the option.