### PR TITLE
Add format literal string to resolve g++ issue for format-security.

### DIFF
--- a/src/tools/hunspell.cxx
+++ b/src/tools/hunspell.cxx
@@ -581,7 +581,7 @@ const char* basename(const char* s, char c) {
 #ifdef HAVE_CURSES_H
 char* scanline(const char* message) {
   char input[INPUTLEN];
-  printw(message);
+  printw("%s", message);
   echo();
   getnstr(input, INPUTLEN);
   noecho();


### PR DESCRIPTION
In ncruses 6.3 version, if there is no format string in function
  printw, g++ complaints it with option -Werr=format-security on.

Signed-off-by: Qiang Wei <qiang.wei@suse.com>