### PR TITLE
Fix #714 OOB string write in hunspell

### DIFF
--- a/src/hunspell/affixmgr.cxx
+++ b/src/hunspell/affixmgr.cxx
@@ -4367,7 +4367,7 @@ void AffixMgr::reverse_condition(std::string& piece) {
       case '^': {
         if (*(k - 1) == ']')
           neg = 1;
-        else
+        else if (neg)
           *(k - 1) = *k;
         break;
       }


### PR DESCRIPTION
This function, reverse_condition, is supposed to rewrite reversed
strings to swap the direction of square brackets and move `^` characters
from the back of a square bracket section to the front. I believe the
intent is to handle inputs like this:

input:
  [abc][^def]
after reverseword:
  ]fed^[]cba[
after reverse_condition:
  [^fed][cba]

However, when the input ends in `^`, this code slides the `^` character
one to the right, overwriting the C string null terminator:

input to reverse_condition:
  'a', 'b', 'c', '^', '\0'
output:
  'a', 'b', 'c', '^', '^'

I think the invariant for this loop is supposed to be that, characters
stay in place if neg is false, and move one to the right if neg is true.
The '^' case in the loop is the only case that doesn't preserve that
invariant, so I'm assuming it's just missing a condition.

https://github.com/hunspell/hunspell/issues/714