### PR TITLE
COPYING.MPL missing from install

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,4 +6,4 @@ pkgconfdir = $(libdir)/pkgconfig
 pkgconf_DATA = hunspell.pc
 
 EXTRA_DIST = license.myspell license.hunspell \
-        ChangeLog.O COPYING.LESSER hunspell.pc.in
+        ChangeLog.O COPYING.LESSER COPYING.MPL hunspell.pc.in


### PR DESCRIPTION
since...

commit 7fd5a5df7601c56af54efbeb0fada78cda65192d
Date:   Sun Nov 12 05:02:58 2017 +0100

    V1 cmdline tests, simplify file structure.
    Make as much as possible UTF-8 input (.good .wrong .sug).
    Dic and aff re unchanged.
    Remove unneeded .test files.

but isn't explained in that commit