### PR TITLE
ofz: fix crash with checkcompoundpattern2[aff|dic]

### DIFF
--- a/oss-fuzz-build.sh
+++ b/oss-fuzz-build.sh
@@ -16,3 +16,4 @@ $CXX $CXXFLAGS -o $OUT/fuzzer -I./src/ $LIB_FUZZING_ENGINE ./src/tools/fuzzer.cx
 #dic/aff combos to test
 cp -f ./tests/korean.* $OUT/
 cp -f ./tests/utf8_nonbmp.* $OUT/
+cp -f ./tests/checkcompoundpattern*.* $OUT/

--- a/src/hunspell/affixmgr.cxx
+++ b/src/hunspell/affixmgr.cxx
@@ -1958,19 +1958,20 @@ struct hentry* AffixMgr::compound_check(const std::string& word,
             // perhaps second word has prefix or/and suffix
             sfx = NULL;
             sfxflag = FLAG_NULL;
-            rv = (compoundflag && !onlycpdrule)
+            rv = (compoundflag && !onlycpdrule && i < word.size())
                      ? affix_check((word.c_str() + i), strlen(word.c_str() + i), compoundflag,
                                    IN_CPD_END)
                      : NULL;
             if (!rv && compoundend && !onlycpdrule) {
               sfx = NULL;
               pfx = NULL;
-              rv = affix_check((word.c_str() + i), strlen(word.c_str() + i), compoundend,
-                               IN_CPD_END);
+              if (i < word.size())
+                rv = affix_check((word.c_str() + i), strlen(word.c_str() + i), compoundend, IN_CPD_END);
             }
 
             if (!rv && !defcpdtable.empty() && words) {
-              rv = affix_check((word.c_str() + i), strlen(word.c_str() + i), 0, IN_CPD_END);
+              if (i < word.size())
+                rv = affix_check((word.c_str() + i), strlen(word.c_str() + i), 0, IN_CPD_END);
               if (rv && defcpd_check(&words, wnum + 1, rv, NULL, 1))
                 return rv_first;
               rv = NULL;


### PR DESCRIPTION
and input text: fuhs

this whole business of using i as an index into word when
if (scpd > 0) adjusted i and len after inserting text into st
looks v. dubious.