### PR TITLE
Removed three redundant .c_str() calls

### DIFF
--- a/src/hunspell/affixmgr.cxx
+++ b/src/hunspell/affixmgr.cxx
@@ -2302,11 +2302,11 @@ int AffixMgr::compound_check_morph(const std::string& word,
       if (rv) {
         presult.push_back(MSEP_FLD);
         presult.append(MORPH_PART);
-        presult.append(st);
+        presult.append(st, 0, i);
         if (!HENTRY_FIND(rv, MORPH_STEM)) {
           presult.push_back(MSEP_FLD);
           presult.append(MORPH_STEM);
-          presult.append(st);
+          presult.append(st, 0, i);
         }
         if (HENTRY_DATA(rv)) {
           presult.push_back(MSEP_FLD);
@@ -2370,7 +2370,7 @@ int AffixMgr::compound_check_morph(const std::string& word,
           if (!p.empty()) {
             presult.push_back(MSEP_FLD);
             presult.append(MORPH_PART);
-            presult.append(st);
+            presult.append(st, 0, i);
             line_uniq_app(p, MSEP_REC);
             presult.append(p);
           }

--- a/src/hunspell/affixmgr.cxx
+++ b/src/hunspell/affixmgr.cxx
@@ -2302,11 +2302,11 @@ int AffixMgr::compound_check_morph(const std::string& word,
       if (rv) {
         presult.push_back(MSEP_FLD);
         presult.append(MORPH_PART);
-        presult.append(st.c_str());
+        presult.append(st);
         if (!HENTRY_FIND(rv, MORPH_STEM)) {
           presult.push_back(MSEP_FLD);
           presult.append(MORPH_STEM);
-          presult.append(st.c_str());
+          presult.append(st);
         }
         if (HENTRY_DATA(rv)) {
           presult.push_back(MSEP_FLD);
@@ -2370,7 +2370,7 @@ int AffixMgr::compound_check_morph(const std::string& word,
           if (!p.empty()) {
             presult.push_back(MSEP_FLD);
             presult.append(MORPH_PART);
-            presult.append(st.c_str());
+            presult.append(st);
             line_uniq_app(p, MSEP_REC);
             presult.append(p);
           }


### PR DESCRIPTION
`presult.append(st.c_str());` → `presult.append(st);`, where `presult` and `st` are `std::string`