### PR TITLE
Some optimizations

### DIFF
--- a/src/hunspell/affixmgr.cxx
+++ b/src/hunspell/affixmgr.cxx
@@ -1358,8 +1358,8 @@ int AffixMgr::cpdcase_check(const char* word, int pos) {
     std::string pair(p);
     std::vector<w_char> pair_u;
     u8_u16(pair_u, pair);
-    unsigned short a = pair_u.size() > 1 ? ((pair_u[1].h << 8) + pair_u[1].l) : 0;
-    unsigned short b = !pair_u.empty() ? ((pair_u[0].h << 8) + pair_u[0].l) : 0;
+    unsigned short a = pair_u.size() > 1 ? (unsigned short)pair_u[1] : 0;
+    unsigned short b = !pair_u.empty() ? (unsigned short)pair_u[0] : 0;
     if (((unicodetoupper(a, langnum) == a) ||
          (unicodetoupper(b, langnum) == b)) &&
         (a != '-') && (b != '-'))

--- a/src/hunspell/hashmgr.cxx
+++ b/src/hunspell/hashmgr.cxx
@@ -589,7 +589,7 @@ int HashMgr::load_tables(const char* tpath, const char* key) {
     return 4;
   }
   tablesize += nExtra;
-  if ((tablesize % 2) == 0)
+  if ((tablesize & 1) == 0)
     tablesize++;
 
   // allocate the hash table
@@ -799,14 +799,14 @@ bool HashMgr::decode_flags(std::vector<unsigned short>& result, const std::strin
   switch (flag_mode) {
     case FLAG_LONG: {  // two-character flags (1x2yZz -> 1x 2y Zz)
       size_t len = flags.size();
-      if (len % 2 == 1)
+      if ((len & 1) == 1)
         HUNSPELL_WARNING(stderr, "error: line %d: bad flagvector\n",
                          af->getlinenum());
-      len /= 2;
+      len >>= 1;
       result.reserve(result.size() + len);
       for (size_t i = 0; i < len; ++i) {
-        result.push_back(((unsigned short)((unsigned char)flags[i * 2]) << 8) +
-                         (unsigned char)flags[i * 2 + 1]);
+        result.push_back(((unsigned short)((unsigned char)flags[i << 1]) << 8) |
+		                 ((unsigned short)((unsigned char)flags[(i << 1) | 1])));
       }
       break;
     }
@@ -866,7 +866,7 @@ unsigned short HashMgr::decode_flag(const std::string& f) const {
   int i;
   switch (flag_mode) {
     case FLAG_LONG:
-      s = ((unsigned short)((unsigned char)f[0]) << 8) + (unsigned char)f[1];
+      s = ((unsigned short)((unsigned char)f[0]) << 8) | ((unsigned short)((unsigned char)f[1]));
       break;
     case FLAG_NUM:
       i = atoi(f.c_str());

--- a/src/hunspell/hunzip.cxx
+++ b/src/hunspell/hunzip.cxx
@@ -136,17 +136,17 @@ int Hunzip::getcode(const char* key) {
         enc = key;
       l ^= *enc;
     }
-    if (!fin.read(in, l / 8 + 1))
+    if (!fin.read(in, (l >> 3) + 1))
       return fail(MSG_FORMAT, filename);
     if (key)
-      for (j = 0; j <= l / 8; j++) {
+      for (j = 0; j <= (l >> 3); j++) {
         if (*(++enc) == '\0')
           enc = key;
         in[j] ^= *enc;
       }
     int p = 0;
     for (j = 0; j < l; j++) {
-      int b = (in[j / 8] & (1 << (7 - (j % 8)))) ? 1 : 0;
+      int b = (in[(j >> 3)] & (1 << (7 - (j & 7)))) ? 1 : 0;
       int oldp = p;
       p = dec[p].v[b];
       if (p == 0) {
@@ -176,10 +176,10 @@ int Hunzip::getbuf() {
   do {
     if (inc == 0) {
       fin.read(in, BUFSIZE);
-      inbits = int(fin.gcount() * 8);
+      inbits = int(fin.gcount() << 3);
     }
     for (; inc < inbits; inc++) {
-      int b = (in[inc / 8] & (1 << (7 - (inc % 8)))) ? 1 : 0;
+      int b = (in[inc >> 3] & (1 << (7 - (inc & 7)))) ? 1 : 0;
       int oldp = p;
       p = dec[p].v[b];
       if (p == 0) {

--- a/src/hunspell/suggestmgr.cxx
+++ b/src/hunspell/suggestmgr.cxx
@@ -1457,25 +1457,25 @@ void SuggestMgr::ngsuggest(std::vector<std::string>& wlst,
       if (utf8) {
         u8_u16(w_gl, gl);
         //w_gl is lowercase already at this point
-        re = ngram(2, w_word, w_gl, NGRAM_ANY_MISMATCH + NGRAM_WEIGHTED);
+        re = ngram(2, w_word, w_gl, NGRAM_ANY_MISMATCH | NGRAM_WEIGHTED);
         if (low) {
           w_f = w_word;
           // lowering dictionary word
           mkallsmall_utf(w_f, langnum);
-          re += ngram(2, w_gl, w_f, NGRAM_ANY_MISMATCH + NGRAM_WEIGHTED);
+          re += ngram(2, w_gl, w_f, NGRAM_ANY_MISMATCH | NGRAM_WEIGHTED);
         } else {
-          re += ngram(2, w_gl, w_word, NGRAM_ANY_MISMATCH + NGRAM_WEIGHTED);
+          re += ngram(2, w_gl, w_word, NGRAM_ANY_MISMATCH | NGRAM_WEIGHTED);
         }
       } else {
         //gl is lowercase already at this point
-        re = ngram(2, word, gl, NGRAM_ANY_MISMATCH + NGRAM_WEIGHTED);
+        re = ngram(2, word, gl, NGRAM_ANY_MISMATCH | NGRAM_WEIGHTED);
         if (low) {
           f = word;
           // lowering dictionary word
           mkallsmall(f, csconv);
-          re += ngram(2, gl, f, NGRAM_ANY_MISMATCH + NGRAM_WEIGHTED);
+          re += ngram(2, gl, f, NGRAM_ANY_MISMATCH | NGRAM_WEIGHTED);
         } else {
-          re += ngram(2, gl, word, NGRAM_ANY_MISMATCH + NGRAM_WEIGHTED);
+          re += ngram(2, gl, word, NGRAM_ANY_MISMATCH | NGRAM_WEIGHTED);
         }
       }
 
@@ -1963,9 +1963,7 @@ int SuggestMgr::ngram(int n,
       int k = 0;
       for (int l = 0; l <= (l2 - j); l++) {
         for (k = 0; k < j; k++) {
-          const w_char& c1 = su1[i + k];
-          const w_char& c2 = su2[l + k];
-          if ((c1.l != c2.l) || (c1.h != c2.h))
+          if (su1[i + k] != su2[l + k])
             break;
         }
         if (k == j) {
@@ -2047,13 +2045,12 @@ int SuggestMgr::leftcommonsubstring(
     if (l1 && l2 && su1[l1 - 1] == su2[l2 - 1])
       return 1;
   } else {
-    unsigned short idx = su2.empty() ? 0 : (su2[0].h << 8) + su2[0].l;
-    unsigned short otheridx = su1.empty() ? 0 : (su1[0].h << 8) + su1[0].l;
+    unsigned short idx = su2.empty() ? 0 : (unsigned short)(su2[0]);
+    unsigned short otheridx = su1.empty() ? 0 : (unsigned short)(su1[0]);
     if (otheridx != idx && (otheridx != unicodetolower(idx, langnum)))
       return 0;
     int i;
-    for (i = 1; (i < l1) && (i < l2) && (su1[i].l == su2[i].l) &&
-                (su1[i].h == su2[i].h);
+    for (i = 1; (i < l1) && (i < l2) && (su1[i] == su2[i]);
          i++)
       ;
     return i;

--- a/src/hunspell/w_char.hxx
+++ b/src/hunspell/w_char.hxx
@@ -40,6 +40,12 @@
 
 #include <string>
 
+#if __cplusplus >= 202002L
+#include <bit>
+#else
+#include <cstring>
+#endif
+
 #ifndef GCC
 struct w_char {
 #else
@@ -48,18 +54,33 @@ struct __attribute__((packed)) w_char {
   unsigned char l;
   unsigned char h;
 
+  operator unsigned short() const
+  {
+#if defined(__i386__) || defined(_M_IX86) || defined(_M_X64)
+    //use little-endian optimized version
+#if __cplusplus >= 202002L
+    return std::bit_cast<unsigned short>(*this);
+#else
+  	unsigned short u;
+    memcpy(&u, this, sizeof(unsigned short));
+    return u;
+#endif
+
+#else
+    return ((unsigned short)h << 8) | (unsigned short)l;
+#endif
+  }
+
   friend bool operator<(const w_char a, const w_char b) {
-    unsigned short a_idx = (a.h << 8) + a.l;
-    unsigned short b_idx = (b.h << 8) + b.l;
-    return a_idx < b_idx;
+    return (unsigned short)a < (unsigned short)b;
   }
 
   friend bool operator==(const w_char a, const w_char b) {
-    return (((a).l == (b).l) && ((a).h == (b).h));
+    return (unsigned short)a == (unsigned short)b;
   }
 
   friend bool operator!=(const w_char a, const w_char b) {
-    return !(a == b);;
+    return !(a == b);
   }
 };
 

--- a/src/parsers/textparser.cxx
+++ b/src/parsers/textparser.cxx
@@ -84,7 +84,7 @@ int TextParser::is_wordchar(const char* w) {
       return wordcharacters[cache_index];
     if (u8_u16(wc, w, true) < 1)
         return 0;
-    unsigned short idx = (wc[0].h << 8) + wc[0].l;
+    unsigned short idx = (unsigned short)wc[0];
     return unicodeisalpha(idx) ||
            (wordchars_utf16 &&
             std::binary_search(wordchars_utf16, wordchars_utf16 + wclen, wc[0]));


### PR DESCRIPTION
This pull request contains some optimizations:

1) Conversions between `w_char` and `unsigned short`. For these conversions, we can use `memcpy` or `std::bit_cast` on little-endian architectures. On big-endian architectures we need additionally swap byte order or order of fields of struct `w_char`, or we can use trivial code with shifts and bitwise operators.  You can see the optimizations in detail on godbolt: [https://godbolt.org/z/vjP5T6vhK](https://godbolt.org/z/vjP5T6vhK) .
2) Some arithmetic operators replaced with shifts and bitwise operators.