### PR TITLE
Remove deprecated minimal rebuild switch.

### DIFF
--- a/msvc/hunspell.vcxproj
+++ b/msvc/hunspell.vcxproj
@@ -89,7 +89,6 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\src\hunspell;..\src\parsers;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>W32;WIN32;_DEBUG;_CONSOLE;HUNSPELL_STATIC;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeader />


### PR DESCRIPTION
Fixes build output like:
```
     3>cl : Command line warning D9035: option 'Gm' has been deprecated and will be removed in a future release [D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\msvc\hunspell.vcxproj]
         manparser.cxx
     3>cl : Command line warning D9035: option 'Gm' has been deprecated and will be removed in a future release [D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\msvc\hunspell.vcxproj]
         latexparser.cxx
     3>cl : Command line warning D9035: option 'Gm' has been deprecated and will be removed in a future release [D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\msvc\hunspell.vcxproj]
         textparser.cxx
     3>cl : Command line warning D9035: option 'Gm' has been deprecated and will be removed in a future release [D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\msvc\hunspell.vcxproj]
         hunspell.cxx
     3>cl : Command line warning D9035: option 'Gm' has been deprecated and will be removed in a future release [D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\msvc\hunspell.vcxproj]
         odfparser.cxx
     3>cl : Command line warning D9035: option 'Gm' has been deprecated and will be removed in a future release [D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\msvc\hunspell.vcxproj]
         htmlparser.cxx
     3>cl : Command line warning D9035: option 'Gm' has been deprecated and will be removed in a future release [D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\msvc\hunspell.vcxproj]
         xmlparser.cxx
     3>cl : command line  warning D9035: option 'Gm' has been deprecated and will be removed in a future release [D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\msvc\hunspell.vcxproj]
         firstparser.cxx
```

as well as works around an ICE:

```
         D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\src\parsers\firstparser.cxx(66,1): error C2471: cannot update program database '???' [D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\msvc\hunspell.vcxproj]
         D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\src\parsers\firstparser.cxx(66,1): error C2471: cannot update program database '' [D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\msvc\hunspell.vcxproj]
         D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\src\parsers\textparser.cxx(303,1): error C2471: cannot update program database 'D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\msvc\Win32\Debug\hunspell\hunspell.pdb' [D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\msvc\hunspell.vcxproj]
         D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\src\parsers\textparser.cxx(303,1): fatal error C1090: PDB API call failed, error code '23': (0x000006BA) [D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\msvc\hunspell.vcxproj]
         D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\src\parsers\xmlparser.cxx(254,1): error C2471: cannot update program database '??T' [D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\msvc\hunspell.vcxproj]
         D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\src\parsers\htmlparser.cxx(89,1): error C2471: cannot update program database '??U' [D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\msvc\hunspell.vcxproj]
         D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\src\parsers\xmlparser.cxx(254,1): error C2471: cannot update program database '' [D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\msvc\hunspell.vcxproj]
         D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\src\parsers\htmlparser.cxx(89,1): error C2471: cannot update program database '' [D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\msvc\hunspell.vcxproj]
         D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\src\parsers\latexparser.cxx(289,1): error C2471: cannot update program database '??O' [D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\msvc\hunspell.vcxproj]
         D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\src\tools\hunspell.cxx(2224,1): error C2471: cannot update program database 'D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\msvc\Win32\Debug\hunspell\hunspell.pdb' [D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\msvc\hunspell.vcxproj]
         D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\src\parsers\latexparser.cxx(289,1): error C2471: cannot update program database '' [D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\msvc\hunspell.vcxproj]
         D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\src\tools\hunspell.cxx(2224,1): fatal error C1090: PDB API call failed, error code '23': (0x000006BA) [D:\buildtrees\hunspell\x86-windows-dbg\v1.7.1-423af297b5.clean\msvc\hunspell.vcxproj]
```

First detected in https://github.com/microsoft/vcpkg/pull/27718