### PR TITLE
this claim is over 12 years old and out of date

### DIFF
--- a/man/hunspell.5
+++ b/man/hunspell.5
@@ -123,7 +123,6 @@ Set flag type. Default type is the extended ASCII (8-bit) character.
 The `long' value sets the double extended ASCII character flag type,
 the `num' sets the decimal number flag type. Decimal flags numbered from 1 to
 65000, and in flag fields are separated by comma.
-BUG: UTF-8 flag type doesn't work on ARM platform.
 .PP
 .RS
 .nf


### PR DESCRIPTION
I don't know of any arm-specific problems anymore and make check which test UTF-8 etc has been working fine in at least Fedora for many years now

https://github.com/hunspell/hunspell/issues/896