### PR TITLE
Cannot add the word "Javascript" to custom dictionary

### DIFF
--- a/src/hunspell/hashmgr.cxx
+++ b/src/hunspell/hashmgr.cxx
@@ -492,29 +492,26 @@ int HashMgr::remove(const std::string& word) {
 }
 
 /* remove forbidden flag to add a personal word to the hash */
-int HashMgr::remove_forbidden_flag(const std::string& word) {
+void HashMgr::remove_forbidden_flag(const std::string& word) {
   struct hentry* dp = lookup(word.c_str(), word.size());
   if (!dp)
-    return 1;
+    return;
   while (dp) {
     if (dp->astr && TESTAFF(dp->astr, forbiddenword, dp->alen))
       dp->alen = 0;  // XXX forbidden words of personal dic.
     dp = dp->next_homonym;
   }
-  return 0;
 }
 
 // add a custom dic. word to the hash table (public)
 int HashMgr::add(const std::string& word) {
-  if (remove_forbidden_flag(word)) {
-    int captype, al = 0;
-    unsigned short* flags = NULL;
-    int wcl = get_clen_and_captype(word, &captype);
-    add_word(word, wcl, flags, al, NULL, false, captype);
-    return add_hidden_capitalized_word(word, wcl, flags, al, NULL,
-                                       captype);
-  }
-  return 0;
+  remove_forbidden_flag(word);
+  int captype, al = 0;
+  unsigned short* flags = NULL;
+  int wcl = get_clen_and_captype(word, &captype);
+  add_word(word, wcl, flags, al, NULL, false, captype);
+  return add_hidden_capitalized_word(word, wcl, flags, al, NULL,
+                                     captype);
 }
 
 int HashMgr::add_with_affix(const std::string& word, const std::string& example) {

--- a/src/hunspell/hashmgr.hxx
+++ b/src/hunspell/hashmgr.hxx
@@ -149,7 +149,7 @@ class HashMgr {
                                   int captype);
   bool parse_aliasm(const std::string& line, FileMgr* af);
   bool parse_reptable(const std::string& line, FileMgr* af);
-  int remove_forbidden_flag(const std::string& word);
+  void remove_forbidden_flag(const std::string& word);
   void free_table();
   void free_flag(unsigned short* astr, short alen);
 };


### PR DESCRIPTION
if base dictionary contains "JavaScript"

https://github.com/hunspell/hunspell/issues/905

we don't check the return value of remove_forbidden_flag in HashMgr::add_with_affix, but we do in HashMgr::add

has been like this since the initial checkin.