### PR TITLE
Do not convert a size_t to an int

### DIFF
--- a/src/hunspell/affixmgr.cxx
+++ b/src/hunspell/affixmgr.cxx
@@ -1320,7 +1320,7 @@ int AffixMgr::cpdwordpair_check(const std::string& word, int wl) {
 
 // forbid compoundings when there are special patterns at word bound
 int AffixMgr::cpdpat_check(const std::string& word,
-                           int pos,
+                           size_t pos,
                            hentry* r1,
                            hentry* r2,
                            const char /*affixed*/) {
@@ -1547,7 +1547,7 @@ short AffixMgr::get_syllable(const std::string& word) {
   return num;
 }
 
-void AffixMgr::setcminmax(int* cmin, int* cmax, const char* word, int len) {
+void AffixMgr::setcminmax(size_t* cmin, size_t* cmax, const char* word, size_t len) {
   if (utf8) {
     int i;
     for (*cmin = 0, i = 0; (i < cpdmin) && *cmin < len; i++) {
@@ -1580,7 +1580,8 @@ struct hentry* AffixMgr::compound_check(const std::string& word,
   hentry *rv = NULL, *rv_first;
   std::string st;
   char ch = '\0', affixed;
-  int cmin, cmax, striple = 0, soldi = 0, oldcmin = 0, oldcmax = 0, oldlen = 0, checkedstriple = 0;
+  size_t cmin, cmax;
+  int striple = 0, soldi = 0, oldcmin = 0, oldcmax = 0, oldlen = 0, checkedstriple = 0;
   hentry** oldwords = words;
   size_t scpd = 0, len = word.size();
 
@@ -1605,7 +1606,7 @@ struct hentry* AffixMgr::compound_check(const std::string& word,
 
   st.assign(word);
 
-  for (int i = cmin; i < cmax; ++i) {
+  for (size_t i = cmin; i < cmax; ++i) {
     // go to end of the UTF-8 character
     if (utf8) {
       for (; (st[i] & 0xc0) == 0x80; i++)
@@ -2191,7 +2192,8 @@ int AffixMgr::compound_check_morph(const std::string& word,
   hentry* rv = NULL, *rv_first;
   std::string st, presult;
   char ch, affixed = 0;
-  int checked_prefix, cmin, cmax, ok = 0;
+  int checked_prefix, ok = 0;
+  size_t cmin, cmax;
   hentry** oldwords = words;
   size_t len = word.size();
 
@@ -2214,7 +2216,7 @@ int AffixMgr::compound_check_morph(const std::string& word,
 
   st.assign(word);
 
-  for (int i = cmin; i < cmax; ++i) {
+  for (size_t i = cmin; i < cmax; ++i) {
     // go to end of the UTF-8 character
     if (utf8) {
       for (; (st[i] & 0xc0) == 0x80; i++)

--- a/src/hunspell/affixmgr.hxx
+++ b/src/hunspell/affixmgr.hxx
@@ -261,7 +261,7 @@ class AffixMgr {
   int cpdrep_check(const std::string& word, int len);
   int cpdwordpair_check(const std::string& word, int len);
   int cpdpat_check(const std::string& word,
-                   int len,
+                   size_t len,
                    hentry* r1,
                    hentry* r2,
                    const char affixed);
@@ -272,7 +272,7 @@ class AffixMgr {
                    char all);
   int cpdcase_check(const std::string& word, int len);
   inline int candidate_check(const std::string& word);
-  void setcminmax(int* cmin, int* cmax, const char* word, int len);
+  void setcminmax(size_t* cmin, size_t* cmax, const char* word, size_t len);
   struct hentry* compound_check(const std::string& word,
                                 short wordnum,
                                 short numsyllable,


### PR DESCRIPTION
This commit fixes various signed/unsigned comparison warnings reported by VisualStudio.