### PR TITLE
accept flagless dic entry

### DIFF
--- a/src/tools/wordforms
+++ b/src/tools/wordforms
@@ -10,11 +10,13 @@ case $1 in
 -s) fx=1; shift;;
 -p) fx=2; shift;;
 esac
+stems=( $( grep -E "^$3(/|$)" $2 ) )
+[ ${#stems[@]} -eq 0 ] && return
 test -h /tmp/wordforms.aff && rm /tmp/wordforms.aff
 ln -s "$PWD/$1" /tmp/wordforms.aff
-# prepared dic only with the query word
-echo 1 >/tmp/wordforms.dic
-grep "^$3/" $2 >>/tmp/wordforms.dic
+# prepared dic only with the stems found
+echo "${#stems[@]}" >/tmp/wordforms.dic
+printf "%s\n" "${stems[@]}" >>/tmp/wordforms.dic
 echo $3 | awk -v "fx=$fx" '
 fx!=2 && FILENAME!="-" && /^SFX/ && NF > 4{split($4,a,"/");clen=($3=="0") ? 0 : length($3);sfx[a[1],clen]=a[1];sfxc[a[1],clen]=clen;next}
 fx!=1 && FILENAME!="-" && /^PFX/ && NF > 4{split($4,a,"/");clen=($3=="0") ? 0 : length($3);pfx[a[1],clen]=a[1];pfxc[a[1],clen]=clen;next}


### PR DESCRIPTION
this change to wordforms:

- will accept a flagless dic entry that matches the search stem and add it to the temporary dic file (previously, wordforms ignored these, meaning it _seemed_ the dictionary did not accept them as words even though it did)
- will add the correct number of dic entries to the top of the temporary dic file (previously this was always "1" even in the case of multiple identical search stems in the source dictionary i.e. >1 entry actually in the temporary dic file)
- will return early (give up) if no entries matching the search stem were found in the source dic file (previously, wordforms processed everything anyway and then returned nothing because the temporary dic file was empty)