### PR TITLE
Search for hunspell dictionaries in system $PREFIX

### DIFF
--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -1,6 +1,6 @@
 bin_PROGRAMS=analyze chmorph hunspell munch unmunch hzip hunzip
 
-AM_CPPFLAGS=-I${top_builddir}/src/hunspell -I${top_srcdir}/src/hunspell -I${top_srcdir}/src/parsers
+AM_CPPFLAGS=-I${top_builddir}/src/hunspell -I${top_srcdir}/src/hunspell -I${top_srcdir}/src/parsers  -DDATADIR=\"$(datadir)\"
 
 hzip_SOURCES=hzip.cxx
 hunzip_SOURCES=hunzip.cxx

--- a/src/tools/hunspell.cxx
+++ b/src/tools/hunspell.cxx
@@ -116,6 +116,9 @@
 #include "../parsers/odfparser.hxx"
 
 #define LIBDIR                \
+  DATADIR "/hunspell:"        \
+  DATADIR "/myspell:"         \
+  DATADIR "/myspell/dicts:"   \
   "/usr/share/hunspell:"      \
   "/usr/share/myspell:"       \
   "/usr/share/myspell/dicts:" \


### PR DESCRIPTION
When packaging hunspell for the Conda ecosystem, we must manually wrap the hunspell binary with a script that injects a custom DICPATH.

This script is necessary because Conda builds hunspell at a custom $PREFIX. So all the system files are installed at $PREFIX/share/. But hunspell searches a list of fixed paths for dictionaries under /usr/share/.

Automake `$(datadir)` stores the system's value for `$PREFIX/usr/share`, so we export that to the compilation and add alternate dictionary search paths using `$(datadir)`.

Fixes https://github.com/hunspell/hunspell/issues/1035