### PR TITLE
test.sh: remove hardcode libtool path, derive path from Makefile

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -5,7 +5,7 @@ SUBDIRS = suggestiontest
 TEST_EXTENSIONS = .dic
 AM_TESTS_ENVIRONMENT = export HUNSPELL=$(top_builddir)/src/tools/hunspell; \
                        export ANALYZE=$(top_builddir)/src/tools/analyze; \
-                       export LIBTOOL=$(top_builddir)/libtool;
+                       export LIBTOOL="$(LIBTOOL)";
 DIC_LOG_COMPILER = $(top_srcdir)/tests/test.sh
 
 TESTS =	\

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -66,15 +66,16 @@ shopt -s expand_aliases
 [[ "$HUNSPELL" = "" ]] && HUNSPELL="$(dirname $0)"/../src/tools/hunspell
 [[ "$ANALYZE" = "" ]] && ANALYZE="$(dirname $0)"/../src/tools/analyze
 [[ "$LIBTOOL" = "" ]] && LIBTOOL="$(dirname $0)"/../libtool
-alias hunspell='"$LIBTOOL" --mode=execute "$HUNSPELL"'
-alias analyze='"$LIBTOOL" --mode=execute "$ANALYZE"'
+libtool=($LIBTOOL)
+alias hunspell='"${libtool[@]}" --mode=execute "$HUNSPELL"'
+alias analyze='"${libtool[@]}" --mode=execute "$ANALYZE"'
 
 if [[ "$VALGRIND" != "" ]]; then
 	mkdir $TEMPDIR 2> /dev/null || :
 	rm -f $TEMPDIR/test.pid* || :
 	mkdir $TEMPDIR/badlogs 2> /dev/null || :
-	alias hunspell='"$LIBTOOL" --mode=execute valgrind --tool=$VALGRIND --leak-check=yes --show-reachable=yes --log-file=$TEMPDIR/test.pid "$HUNSPELL"'
-	alias analyze='"$LIBTOOL" --mode=execute valgrind --tool=$VALGRIND --leak-check=yes --show-reachable=yes --log-file=$TEMPDIR/test.pid "$ANALYZE"'
+	alias hunspell='"${libtool[@]}" --mode=execute valgrind --tool=$VALGRIND --leak-check=yes --show-reachable=yes --log-file=$TEMPDIR/test.pid "$HUNSPELL"'
+	alias analyze='"${libtool[@]}" --mode=execute valgrind --tool=$VALGRIND --leak-check=yes --show-reachable=yes --log-file=$TEMPDIR/test.pid "$ANALYZE"'
 fi
 
 CR=$(printf "\r")


### PR DESCRIPTION
When running the tests when hunspell was built with slibtoolize + slibtool most tests fail because of a hardcoded libtool path.
```
../tests/test.sh: line 93: ../libtool: No such file or directory
```
This patch removes the hardcoded libtool, derives the value from the Makefile and sets it as a bash array in test.sh so that the default GNU libtool value works.

Gentoo-Issue: https://bugs.gentoo.org/958376