### PR TITLE
Add a missing include in csutil.cxx

### DIFF
--- a/src/hunspell/csutil.cxx
+++ b/src/hunspell/csutil.cxx
@@ -74,6 +74,7 @@
 #include <cstring>
 #include <cstdio>
 #include <cctype>
+#include <iterator>
 #include <sstream>
 #if __cplusplus >= 202002L
 #include <bit>


### PR DESCRIPTION
`itearator` header is necessary for `std::back_inserter` in some build config.