### PR TITLE
Draft: add support for configuring directory for personal dicts

### DIFF
--- a/src/tools/hunspell.cxx
+++ b/src/tools/hunspell.cxx
@@ -141,7 +141,9 @@
   "/usr/lib/openoffice.org2.1/share/dict/ooo:"       \
   "/opt/openoffice.org2.0/share/dict/ooo:"           \
   "/usr/lib/openoffice.org2.0/share/dict/ooo"
-#define HOME getenv("HOME")
+#define HOME                                           \
+  ((getenv("HUNSPELL_DATA")) ? getenv("HUNSPELL_DATA") \
+                             : getenv("HOME"))
 #define DICBASENAME ".hunspell_"
 #define LOGFILE "/tmp/hunspell.log"
 #define DIRSEPCH '/'


### PR DESCRIPTION
fixes #1028 

This is an initial idea towards making the directory for personal dictionaries configurable by environment variable.

Ideally this would use `$XDG_DATA_HOME` and fall back to `~/.local/share/hunspell`, but I couldn't get that working, I would get "cannot update personal dictionary" (thrown by l. 1384) using this statement to set the directory:
```cpp
#define HOME
    ((getenv("XDG_DATA_HOME")) ? strcat(getenv("XDG_DATA_HOME"), "/hunspell")
                                                          : strcat(getenv("HOME"), "/.local/share/hunspell")
```
for which I don't quite understand why it doesn't work.

Additionally that would break current function and is not a good way to implement that, would still need to preserve `$HOME` as a possible directory.