### PR TITLE
MSVC C++ does not properly support the _cplusplus macro

### DIFF
--- a/src/hunspell/csutil.cxx
+++ b/src/hunspell/csutil.cxx
@@ -76,7 +76,7 @@
 #include <cctype>
 #include <iterator>
 #include <sstream>
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
 #include <bit>
 #endif
 
@@ -570,7 +570,7 @@ w_char upper_utf(w_char u, int langnum) {
 //but g++ remains in five instructions
 //maybe use inline asm for g++?
 
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
   return std::bit_cast<w_char>(unicodetoupper((unsigned short)u, langnum));
 #else
   const auto us = unicodetoupper((unsigned short)u, langnum);
@@ -594,7 +594,7 @@ w_char lower_utf(w_char u, int langnum) {
 //but g++ remains in five instructions
 //maybe use inline asm for g++?
 
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
   return std::bit_cast<w_char>(unicodetolower((unsigned short)u, langnum));
 #else
   const auto us = unicodetolower((unsigned short)u, langnum);

--- a/src/hunspell/hashmgr.cxx
+++ b/src/hunspell/hashmgr.cxx
@@ -74,7 +74,7 @@
 #include <cctype>
 #include <limits>
 #include <sstream>
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
 #include <bit>
 #endif
 
@@ -929,7 +929,7 @@ std::string HashMgr::encode_flag(unsigned short f) const {
 
 #if defined(__i386__) || defined(_M_IX86) || defined(_M_X64)
 
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
     auto wc = std::bit_cast<w_char>(f);
 #else
     w_char wc;

--- a/src/hunspell/w_char.hxx
+++ b/src/hunspell/w_char.hxx
@@ -40,7 +40,7 @@
 
 #include <string>
 
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
 #include <bit>
 #else
 #include <cstring>
@@ -58,7 +58,7 @@ struct __attribute__((packed)) w_char {
   {
 #if defined(__i386__) || defined(_M_IX86) || defined(_M_X64)
     //use little-endian optimized version
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
     return std::bit_cast<unsigned short>(*this);
 #else
     unsigned short u;


### PR DESCRIPTION
In MSVC it always reports 199711L, and Microsoft recommends to use _MSVC_LANG.

<https://learn.microsoft.com/de-de/cpp/build/reference/zc-cplusplus>