### PR TITLE
README: make macOS install explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Then run:
     autoreconf -vfi
     ./configure
     make
+    sudo make install
 
 # Compiling on Windows
 


### PR DESCRIPTION
missing one command in the macOS compilation instructions