### PR TITLE
WaE: fix macos ci

### DIFF
--- a/src/hunspell/affixmgr.cxx
+++ b/src/hunspell/affixmgr.cxx
@@ -1602,8 +1602,7 @@ struct hentry* AffixMgr::compound_check(const std::string& word,
       clock_time_start = clock_now;
       timelimit_exceeded = false;
   }
-  else if (std::chrono::duration_cast<std::chrono::milliseconds>(clock_now - clock_time_start).count()
-            > TIMELIMIT_MS)
+  else if (clock_now - clock_time_start > TIMELIMIT_MS)
       timelimit_exceeded = true;
 
   setcminmax(&cmin, &cmax, word.c_str(), len);
@@ -2231,8 +2230,7 @@ int AffixMgr::compound_check_morph(const std::string& word,
       clock_time_start = clock_now;
       timelimit_exceeded = false;
   }
-  else if (std::chrono::duration_cast<std::chrono::milliseconds>(clock_now - clock_time_start).count()
-            > TIMELIMIT_MS)
+  else if (clock_now - clock_time_start > TIMELIMIT_MS)
       timelimit_exceeded = true;
 
   setcminmax(&cmin, &cmax, word.c_str(), len);

--- a/src/hunspell/atypes.hxx
+++ b/src/hunspell/atypes.hxx
@@ -54,6 +54,7 @@ static inline void HUNSPELL_WARNING(FILE*, const char*, ...) {}
 
 #include "w_char.hxx"
 #include <algorithm>
+#include <chrono>
 #include <string>
 #include <vector>
 
@@ -104,8 +105,8 @@ static inline void HUNSPELL_WARNING(FILE*, const char*, ...) {}
 #define TIMELIMIT_GLOBAL (CLOCKS_PER_SEC / 4)
 #define TIMELIMIT_SUGGESTION (CLOCKS_PER_SEC / 10)
 #define TIMELIMIT (CLOCKS_PER_SEC / 20)
-#define TIMELIMIT_SUGGESTION_MS (TIMELIMIT_SUGGESTION * 1000 / CLOCKS_PER_SEC)
-#define TIMELIMIT_MS (TIMELIMIT * 1000 / CLOCKS_PER_SEC)
+#define TIMELIMIT_SUGGESTION_MS std::chrono::milliseconds(TIMELIMIT_SUGGESTION * 1000 / CLOCKS_PER_SEC)
+#define TIMELIMIT_MS std::chrono::milliseconds(TIMELIMIT * 1000 / CLOCKS_PER_SEC)
 #define MINTIMER 100
 #define MAXPLUSTIMER 100
 


### PR DESCRIPTION
affixmgr.cxx:1606:13: error: comparison of integers of different signs: 'std::chrono::duration<long long, std::ratio<1, 1000>>::rep' (aka 'long long') and 'unsigned long' [-Werror,-Wsign-compare]
            > TIMELIMIT_MS)
            ^ ~~~~~~~~~~~~