### PR TITLE
Fix stack-buffer-overflow in Hunzip::getline

### DIFF
--- a/src/hunspell/hunzip.cxx
+++ b/src/hunspell/hunzip.cxx
@@ -210,7 +210,10 @@ bool Hunzip::getline(std::string& dest) {
   int l = 0, eol = 0, left = 0, right = 0;
   if (bufsiz == -1)
     return false;
-  while (l < bufsiz && !eol) {
+  // Stop one byte before BUFSIZE so the post-loop linebuf[l] = '\0' below
+  // (and the right-suffix path) always have room for the terminator without
+  // overflowing the stack buffer.
+  while (l < bufsiz && l < BUFSIZE - 1 && !eol) {
     linebuf[l++] = out[outc];
     switch (out[outc]) {
       case '\t':

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,9 +4,11 @@ SUBDIRS = suggestiontest
 
 AM_CPPFLAGS = -I$(top_srcdir)/src/hunspell
 
-check_PROGRAMS = gh1032
+check_PROGRAMS = gh1032 gh-hunzip-overflow
 gh1032_SOURCES = gh1032.cxx
 gh1032_LDADD = $(top_builddir)/src/hunspell/libhunspell-1.7.la
+gh_hunzip_overflow_SOURCES = gh-hunzip-overflow.cxx
+gh_hunzip_overflow_LDADD = $(top_builddir)/src/hunspell/libhunspell-1.7.la
 
 TEST_EXTENSIONS = .dic
 AM_TESTS_ENVIRONMENT = export HUNSPELL=$(top_builddir)/src/tools/hunspell; \
@@ -148,6 +150,7 @@ limit-multiple-compounding.dic \
 iconv_break_overflow.dic \
 gh1076.dic \
 gh1032.test \
+gh-hunzip-overflow.test \
 gh1086.test \
 gh1018.test \
 gh1044.test \
@@ -686,6 +689,8 @@ gh1032.cxx \
 gh1032.aff \
 gh1032.dic \
 gh1032.test \
+gh-hunzip-overflow.cxx \
+gh-hunzip-overflow.test \
 gh1086.aff \
 gh1086.dic \
 gh1086.txt \

--- a/tests/gh-hunzip-overflow.cxx
+++ b/tests/gh-hunzip-overflow.cxx
@@ -1,0 +1,66 @@
+// Regression test for stack-buffer-overflow in Hunzip::getline.
+//
+// A crafted .aff.hz that decompresses to BUFSIZE printable bytes with no
+// EOL caused linebuf[BUFSIZE] = '\0' to write one byte past the end of the
+// 65 KiB stack buffer. Reproducible through the public Hunspell constructor
+// because FileMgr falls through to Hunzip when only the .aff.hz exists.
+//
+// Run under ASan/UBSan: this program must complete without a sanitizer error.
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include "../src/hunspell/hunspell.hxx"
+
+static int write_poc(const char* path) {
+    // Header: magic "hz0" + 16-bit big-endian record count (=2)
+    // Code 1: c=('a','a'), len=1 bit, bits "0"
+    // Code 2: c=('b','b'), len=1 bit, bits "1"
+    // 8192 zero bytes -> 65536 zero bits -> 32768 "aa" pairs = 65536 'a' bytes.
+    static const unsigned char hdr[] = {
+        'h','z','0',
+        0x00, 0x02,
+        'a','a', 0x01, 0x00,
+        'b','b', 0x01, 0x80,
+    };
+    FILE* f = fopen(path, "wb");
+    if (!f) return 1;
+    if (fwrite(hdr, 1, sizeof hdr, f) != sizeof hdr) { fclose(f); return 1; }
+    static const unsigned char zero[1024] = {0};
+    for (int i = 0; i < 8; ++i)
+        if (fwrite(zero, 1, sizeof zero, f) != sizeof zero) { fclose(f); return 1; }
+    fclose(f);
+    return 0;
+}
+
+int main(int argc, char** argv) {
+    const char* tmpdir = getenv("TMPDIR");
+    if (!tmpdir || !*tmpdir) tmpdir = "/tmp";
+
+    std::string base(tmpdir);
+    base += "/hunspell-gh-hunzip-overflow";
+    std::string aff = base + ".aff";        // intentionally absent
+    std::string aff_hz = base + ".aff.hz";  // crafted
+    std::string dic = base + ".dic";        // empty stub is fine
+
+    // Make sure no stale .aff is around so FileMgr falls through to .hz.
+    remove(aff.c_str());
+
+    if (write_poc(aff_hz.c_str()) != 0) {
+        fprintf(stderr, "FAIL: cannot write %s\n", aff_hz.c_str());
+        return 1;
+    }
+    FILE* d = fopen(dic.c_str(), "w");
+    if (!d) { fprintf(stderr, "FAIL: cannot write %s\n", dic.c_str()); return 1; }
+    fclose(d);
+
+    // The constructor must not trigger a sanitizer error. Pre-fix, ASan reports
+    //   stack-buffer-overflow ... WRITE of size 1 ... in Hunzip::getline
+    Hunspell h(aff.c_str(), dic.c_str());
+    h.spell(std::string("test"));
+
+    remove(aff_hz.c_str());
+    remove(dic.c_str());
+    (void)argc; (void)argv;
+    return 0;
+}

--- a/tests/gh-hunzip-overflow.test
+++ b/tests/gh-hunzip-overflow.test
@@ -1,0 +1,11 @@
+#!/bin/sh
+DIR="$(dirname "$0")"
+LIBTOOL="${LIBTOOL:-$DIR/../libtool}"
+$LIBTOOL --mode=execute "$DIR/../tests/gh-hunzip-overflow"
+rc=$?
+if [ $rc -ne 0 ]; then
+    echo "FAIL: gh-hunzip-overflow crashed with exit code $rc"
+    exit 1
+fi
+echo "PASS: gh-hunzip-overflow"
+exit 0


### PR DESCRIPTION
Close https://github.com/hunspell/hunspell/issues/1105:
A crafted .aff.hz / .dic.hz that decompresses to BUFSIZE bytes with no EOL marker drove the loop in Hunzip::getline until l == BUFSIZE, after which linebuf[l] = '\0' wrote one byte past the end of the 65 KiB stack buffer.

Reachable via the public Hunspell constructor: FileMgr falls through to Hunzip when the plain .aff is missing but .aff.hz is present, so the chain Hunspell -> HashMgr::HashMgr -> HashMgr::load_config -> FileMgr::getline -> Hunzip::getline triggers the OOB on the first hzipped read.

Stop the read loop one byte before BUFSIZE so the post-loop terminator always fits.

Add tests/gh-hunzip-overflow that builds the minimal PoC and asserts the constructor finishes without a sanitizer abort.