### PR TITLE
Add hzfuzzer for Hunzip (.hz) decoder

### DIFF
--- a/src/tools/hzfuzzer.cxx
+++ b/src/tools/hzfuzzer.cxx
@@ -1,0 +1,72 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+/* ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either the GNU General Public License Version 2 or later (the "GPL"), or
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the MPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the MPL, the GPL or the LGPL.
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+// Fuzzer for the Hunzip (.hz) decoder. The other fuzzers in this directory
+// drive the spell-check / parse pipeline through .aff and .dic files and do
+// not exercise the hzip decompression path. FileMgr opens a .aff.hz / .dic.hz
+// when the plain file is missing, so a malformed .hz is a reachable surface.
+
+#include "../hunspell/filemgr.hxx"
+#include "../hunspell/hunzip.hxx"
+#include <fstream>
+#include <string>
+#include <unistd.h>
+
+extern "C" int LLVMFuzzerTestOneInput(const char* data, size_t size)
+{
+    if (size < 3)
+        return 0;
+
+    const char* path = "/tmp/htest.hz";
+    std::ofstream out(path, std::ios_base::out | std::ios_base::trunc | std::ios_base::binary);
+    out.write(data, size);
+    out.close();
+
+    {
+        Hunzip hz(path);
+        std::string line;
+        int n = 0;
+        while (hz.getline(line) && n < 1024)
+            ++n;
+    }
+
+    {
+        // FileMgr appends ".hz" when the plain file is absent.
+        const char* base = "/tmp/htest";
+        unlink(base);
+        FileMgr fm(base);
+        std::string line;
+        int n = 0;
+        while (fm.getline(line) && n < 1024)
+            ++n;
+    }
+
+    return 0;
+}
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
Add the fuzzer `hzfuzzer.cxx` for https://github.com/hunspell/hunspell/issues/1105:

The existing fuzzers (fuzzer, affdicfuzzer, persdicfuzzer, parserfuzzer) drive the spell-check and parse pipelines via .aff and .dic files and do not exercise the hzip decompression path. FileMgr opens .aff.hz / .dic.hz when the plain file is missing, so a malformed .hz is a reachable surface; the recently fixed Hunzip::getline stack-buffer-overflow is an example.

This adds a small driver that writes the fuzz input to a .hz file and exercises both Hunzip directly and the FileMgr fallthrough path.