### PR TITLE
Trie data structure for much faster ICONV handling

### DIFF
--- a/src/hunspell/replist.cxx
+++ b/src/hunspell/replist.cxx
@@ -78,6 +78,7 @@
 
 RepList::RepList(int n) {
   dat.reserve(std::min(n, 16384));
+  can_use_trie = true;
 }
 
 RepList::~RepList() {
@@ -118,15 +119,20 @@ int RepList::add(const std::string& in_pat1, const std::string& pat2) {
   if (in_pat1.empty() || pat2.empty()) {
     return 1;
   }
+
+  trie.add(in_pat1, pat2);
+
   // analyse word context
   int type = 0;
   std::string pat1(in_pat1);
   if (pat1[0] == '_') {
     pat1.erase(0, 1);
     type = 1;
+    can_use_trie = false;
   }
   if (!pat1.empty() && pat1[pat1.size() - 1] == '_') {
     type = type + 2;
+    can_use_trie = false;
     pat1.erase(pat1.size() - 1);
   }
   mystrrep(pat1, "_", " ");
@@ -159,6 +165,9 @@ int RepList::add(const std::string& in_pat1, const std::string& pat2) {
 }
 
 bool RepList::conv(const std::string& in_word, std::string& dest) {
+  if (can_use_trie)
+    return trie.transcode(in_word, dest) != TranscodeResult::None;
+
   dest.clear();
 
   const size_t wordlen = in_word.size();

--- a/src/hunspell/replist.hxx
+++ b/src/hunspell/replist.hxx
@@ -77,9 +77,236 @@
 #include <string>
 #include <vector>
 
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <string>
+#include <map>
+#include <chrono>
+#include <limits>
+#include <random>
+#include <cstring>
+#include <cstdint>
+
+// ============================================================================
+// Transcoding Outcomes
+// ============================================================================
+enum class TranscodeResult {
+    None,       // All bytes were copied verbatim; no substitutions were found.
+    Partial,    // A mix of valid substitutions and verbatim copies occurred.
+    All         // Every byte of the input was successfully mapped and substituted.
+};
+
+// ============================================================================
+// Configurable Trie Template Class
+// ============================================================================
+template <typename IndexType, bool UseNibbles>
+class Trie {
+public:
+    // A trie node stores relative offsets to its children.
+    // By avoiding absolute pointers, we compress the tree and allow the underlying
+    // vector to reallocate without invalidating links.
+    // Size math:
+    // - UseNibbles=true : 16 * sizeof(IndexType) -> Power of two
+    // - UseNibbles=false: 256 * sizeof(IndexType) -> Power of two
+    struct Node {
+        static constexpr size_t ALPHABET_SIZE = UseNibbles ? 16 : 256;
+        
+        // Zero-initialization via brace-enclosed list. 
+        // This avoids the overhead of a manual for-loop during node construction.
+        // A '0' offset mathematically represents a null/missing child, as any 
+        // valid child added to the arena will have an offset of at least 1.
+        IndexType children[ALPHABET_SIZE] = {0};
+    };
+
+private:
+    // ALGORITHM: Arena Allocation
+    // Instead of using `new Node()` which fragments the heap and destroys cache locality,
+    // we use flat std::vectors. Traversing the trie simply means jumping forward 
+    // in this contiguous block of memory.
+    std::vector<Node> nodes;
+    
+    // Parallel arena storing substitution data. We keep this OUT of the Node struct 
+    // to preserve the power-of-two size requirement for fast node array lookups.
+    // Format: 24 bits for the char_arena offset, 8 bits for the length.
+    std::vector<uint32_t> sub_info_arena;
+    
+    // Contiguous byte buffer storing all the actual string substitution values.
+    std::vector<char> char_arena;
+
+    // Failsafe state flag (avoids C++ exceptions)
+    bool status_ok;
+
+    // ALGORITHM: Advance or Create (Trie Insertion)
+    // 1. Check if the transition for the given symbol exists.
+    // 2. If yes, return the absolute index of the child.
+    // 3. If no, calculate the distance from the current node to the END of the arena.
+    // 4. Ensure this distance fits within the user-configured IndexType.
+    // 5. Store this relative distance, emplace a new empty node, and return its index.
+    size_t advance_or_create(size_t curr_idx, uint8_t symbol) {
+        IndexType rel_idx = nodes[curr_idx].children[symbol];
+        if (rel_idx == 0) {
+            size_t new_idx = nodes.size();
+            size_t diff = new_idx - curr_idx;
+            
+            // Diagnostics: Halt execution if the trie outgrows the integer type
+            if (diff > std::numeric_limits<IndexType>::max()) {
+                status_ok = false;
+                return 0;
+            }
+            
+            nodes[curr_idx].children[symbol] = static_cast<IndexType>(diff);
+            
+            // emplace_back constructs the object directly in the vector's memory
+            nodes.emplace_back(); 
+            sub_info_arena.push_back(0xFFFFFFFF); // 0xFFFFFFFF = No substitution mapped here
+            return new_idx;
+        }
+        return curr_idx + rel_idx;
+    }
+
+public:
+    Trie() : status_ok(true) {
+        // Initialize the root node (Index 0)
+        nodes.emplace_back();
+        sub_info_arena.push_back(0xFFFFFFFF);
+    }
+
+    void add(const std::string& key, const std::string& value) {
+        if (!status_ok) return;
+
+        // Size rules diagnostics for our 32-bit (24/8) packing format
+        if (value.size() > 255) { status_ok = false; return; }
+        size_t offset = char_arena.size();
+        if (offset > 0xFFFFFF) { status_ok = false; return; }
+
+        // Append to the flat char arena
+        char_arena.insert(char_arena.end(), value.begin(), value.end());
+        uint32_t sub_val = (static_cast<uint32_t>(offset) << 8) | static_cast<uint8_t>(value.size());
+
+        size_t curr_idx = 0;
+        
+        // Traverse the key, adding nodes as necessary
+        for (size_t i = 0; i < key.size(); ++i) {
+            uint8_t byte = static_cast<uint8_t>(key[i]);
+            
+            if (UseNibbles) {
+                // Loop unrolling: Process the High Nibble, then the Low Nibble
+                curr_idx = advance_or_create(curr_idx, (byte >> 4) & 0x0F);
+                if (!status_ok) return;
+                curr_idx = advance_or_create(curr_idx, byte & 0x0F);
+                if (!status_ok) return;
+            } else {
+                // Process as a single 8-bit lookup
+                curr_idx = advance_or_create(curr_idx, byte);
+                if (!status_ok) return;
+            }
+        }
+        // Mark the leaf node with the packed substitution metadata
+        sub_info_arena[curr_idx] = sub_val;
+    }
+
+    void init(const std::map<std::string, std::string>& dict) {
+        for (auto const& pair : dict) {
+            add(pair.first, pair.second);
+        }
+        // ALGORITHM: Capacity trimming
+        // Vectors often allocate more memory than needed (e.g., doubling capacity).
+        // Since initialization is over, we strip away all excess capacity to 
+        // absolutely minimize memory footprint.
+        nodes.shrink_to_fit();
+        sub_info_arena.shrink_to_fit();
+        char_arena.shrink_to_fit();
+    }
+
+    // ALGORITHM: Longest-Prefix Match Transcoding with 3-State Outcome Tracking
+    // Scans the source string and attempts to dive as deep as possible into the trie
+    // for each character. Tracks whether we successfully applied substitutions, 
+    // fell back to verbatim copies, or a mix of both.
+    TranscodeResult transcode(const std::string& src, std::string& dst) const {
+        // Halt and return None if the trie is in an invalid memory state
+        if (!status_ok || src.empty()) return TranscodeResult::None;
+        
+        dst.clear();
+        dst.reserve(src.size()); 
+        
+        // State trackers for the 3-way outcome
+        bool any_substituted = false;
+        bool any_copied = false;
+        
+        size_t i = 0;
+        
+        while (i < src.size()) {
+            size_t curr_idx = 0;
+            size_t match_len = 0;
+            uint32_t best_sub = 0xFFFFFFFF;
+
+            size_t j = i;
+            
+            // Greedily traverse the trie to find the longest matching sequence
+            while (j < src.size()) {
+                uint8_t byte = static_cast<uint8_t>(src[j]);
+                
+                if (UseNibbles) {
+                    IndexType r1 = nodes[curr_idx].children[(byte >> 4) & 0x0F];
+                    if (r1 == 0) break;
+                    curr_idx += r1;
+
+                    IndexType r2 = nodes[curr_idx].children[byte & 0x0F];
+                    if (r2 == 0) break;
+                    curr_idx += r2;
+                } else {
+                    IndexType r = nodes[curr_idx].children[byte];
+                    if (r == 0) break;
+                    curr_idx += r;
+                }
+                
+                ++j;
+                
+                // Track the deepest valid match found during traversal
+                if (sub_info_arena[curr_idx] != 0xFFFFFFFF) {
+                    best_sub = sub_info_arena[curr_idx];
+                    match_len = j - i;
+                }
+            }
+
+            if (best_sub != 0xFFFFFFFF) {
+                // Decode the 24-bit offset and 8-bit size, append directly from arena
+                dst.append(&char_arena[best_sub >> 8], best_sub & 0xFF);
+                i += match_len;
+                any_substituted = true; // State update: Substitution occurred
+            } else {
+                // Fallback: copy unmapped character directly to output
+                dst.push_back(src[i]);
+                ++i;
+                any_copied = true; // State update: Verbatim copy occurred
+            }
+        }
+        
+        // ALGORITHM: Outcome Evaluation
+        if (any_substituted && any_copied) {
+            return TranscodeResult::Partial;
+        } else if (any_substituted) {
+            return TranscodeResult::All;
+        }
+        
+        return TranscodeResult::None;
+    }
+
+    size_t get_arena_size() const {
+        return (nodes.capacity() * sizeof(Node)) +
+               (sub_info_arena.capacity() * sizeof(uint32_t)) +
+               (char_arena.capacity() * sizeof(char));
+    }
+
+    bool get_status() const { return status_ok; }
+};
+
 class RepList {
  private:
   std::vector<replentry*> dat;
+  Trie<uint16_t, true> trie;
+  bool can_use_trie;
  public:
   explicit RepList(int n);
   RepList(const RepList&) = delete;


### PR DESCRIPTION
This is a prototype that was "vibe coded" via
  https://gemini.google.com/share/e6ac3b792fe3

How to benchmark:

  wget https://github.com/375gnu/spell-be-tarask/releases/download/v0.65/hunspell-be-tarask-0.65.zip
  unzip hunspell-be-tarask-0.65.zip
  wget https://raw.githubusercontent.com/375gnu/spell-be-tarask/refs/tags/v0.65/wordlist

  hyperfine -i "./hunspell.before -d be_BY@tarask -l wordlist" \
               "./hunspell.after -d be_BY@tarask -l wordlist"

  Benchmark 1: ./hunspell.before -d be_BY@tarask -l wordlist
    Time (mean ± σ):     11.534 s ±  0.149 s    [User: 11.440 s, System: 0.026 s]
    Range (min … max):   11.415 s … 11.817 s    10 runs

  Benchmark 2: ./hunspell.after -d be_BY@tarask -l wordlist
    Time (mean ± σ):     10.804 s ±  0.037 s    [User: 10.774 s, System: 0.024 s]
    Range (min … max):   10.748 s … 10.861 s    10 runs

  Summary
    ./hunspell.after -d be_BY@tarask -l wordlist ran
      1.07 ± 0.01 times faster than ./hunspell.before -d be_BY@tarask -l wordlist

The current implementation of ICONV substitution in Hunspell is very far from optimal. This pull request implements memory efficient and fast Trie data structure for substrings substitution. Later it can be also taken into use for handling the IGNORE directive (replace strings with an empty string) and to simultaneously transcode from multibyte UTF-8 representation to 8-bit indexes of the alphabet letters (to take advantage of the existing 8-bit pipeline that exists for handling legacy 8-bit codepages).