### PR TITLE
Reduce hentry struct padding by reordering fields

### DIFF
--- a/src/hunspell/htypes.hxx
+++ b/src/hunspell/htypes.hxx
@@ -62,13 +62,18 @@
 #  define HUNSPELL_THREAD_LOCAL static
 #endif
 
+// Field order chosen to minimize internal padding: pointer-sized fields
+// first, then 2-byte fields, then 1-byte fields. This packs sizeof(hentry)
+// to 20 bytes on 32-bit platforms (vs 24 with mixed ordering) and 32 bytes
+// on 64-bit (vs 40), which adds up to several MB on large dictionaries
+// (e.g. Bulgarian, ~700K entries).
 struct hentry {
+  unsigned short* astr;         // affix flag vector
+  struct hentry* next;          // next word with same hash code
+  struct hentry* next_homonym;  // next homonym word (with same hash code)
   unsigned short blen;   // word length in bytes
   unsigned short clen;   // word length in characters (different for UTF-8 enc.)
   short alen;            // length of affix flag vector
-  unsigned short* astr;  // affix flag vector
-  struct hentry* next;   // next word with same hash code
-  struct hentry* next_homonym;  // next homonym word (with same hash code)
   char var;      // bit vector of H_OPT hentry options
   char word[1];  // variable-length word (8-bit or UTF-8 encoding)
 };


### PR DESCRIPTION
Reorders the fields of `struct hentry` so pointer-sized fields come first, followed by 2-byte fields, then 1-byte fields. With the previous mixed ordering the compiler inserted padding between the 6-byte run of `unsigned short`/`short` fields and the pointer trio that followed them.

After the reorder:

| Platform | Before | After |
|---|---|---|
| 32-bit (e.g. wasm32) | 24 bytes | 20 bytes |
| 64-bit | 40 bytes | 32 bytes |

For large dictionaries this adds up. Bulgarian (~700K entries) saves roughly 2.8 MB on 32-bit and 5.6 MB on 64-bit. Smaller dictionaries see proportional savings.

This is a pure layout change. No behavior is modified; no header is added or removed. `make check` passes 149/149 locally on Linux x86_64.

We are soon to be carrying this as a downstream patch in Firefox and figured it would be useful upstream too.