### PR TITLE
Add bump-pointer arena allocator for load-time HashMgr allocations

### DIFF
--- a/src/hunspell/hashmgr.cxx
+++ b/src/hunspell/hashmgr.cxx
@@ -68,12 +68,16 @@
  * SUCH DAMAGE.
  */
 
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
 #include <cstdlib>
 #include <cstring>
 #include <cstdio>
 #include <cctype>
 #include <limits>
 #include <sstream>
+#include <type_traits>
 #if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
 #include <bit>
 #endif
@@ -118,7 +122,7 @@ void HashMgr::free_table() {
     while (ptr) {
       nt = ptr->next;
       release_flags(ptr->astr, ptr->var & H_OPT_OWNFLAGS);
-      free(ptr);
+      arena_free(ptr);
       ptr = nt;
     }
   }
@@ -128,12 +132,16 @@ void HashMgr::free_table() {
 HashMgr::~HashMgr() {
   free_table();
 
+  static_assert(std::is_trivially_destructible<unsigned short>::value,
+                "arena_free replaces delete[]; aliasf elements must have trivial destructors");
   for (auto& j : aliasf)
-    delete[] j;
+    arena_free(j);
   aliasf.clear();
 
+  static_assert(std::is_trivially_destructible<char>::value,
+                "arena_free replaces delete[]; aliasm elements must have trivial destructors");
   for (auto& j : aliasm)
-    delete[] j;
+    arena_free(j);
   aliasm.clear();
 
 #ifdef MOZILLA_CLIENT
@@ -221,7 +229,8 @@ int HashMgr::add_word(const std::string& in_word,
   int descl = desc ? (!aliasm.empty() ? sizeof(char*) : desc->size() + 1) : 0;
   // variable-length hash record with word and optional fields
   auto hp =
-      (struct hentry*)malloc(sizeof(struct hentry) + word->size() + descl);
+      (struct hentry*)arena_alloc(sizeof(struct hentry) + word->size() + descl,
+                                  alignof(struct hentry));
   if (!hp) {
     delete desc_copy;
     delete word_copy;
@@ -374,7 +383,7 @@ int HashMgr::add_word(const std::string& in_word,
           dp->alen = hp->alen;
           dp->var &= ~H_OPT_OWNFLAGS;
           dp->var |= (hp->var & H_OPT_OWNFLAGS);
-          free(hp);
+          arena_free(hp);
           delete desc_copy;
           delete word_copy;
           return 0;
@@ -382,7 +391,7 @@ int HashMgr::add_word(const std::string& in_word,
                    !hp->astr && hp->alen == 0) {
           // word already exists with no flags, skip duplicate
           release_flags(hp->astr, hp->var & H_OPT_OWNFLAGS);
-          free(hp);
+          arena_free(hp);
           delete desc_copy;
           delete word_copy;
           return 0;
@@ -404,7 +413,7 @@ int HashMgr::add_word(const std::string& in_word,
         dp->alen = hp->alen;
         dp->var &= ~H_OPT_OWNFLAGS;
         dp->var |= (hp->var & H_OPT_OWNFLAGS);
-        free(hp);
+        arena_free(hp);
         delete desc_copy;
         delete word_copy;
         return 0;
@@ -412,7 +421,7 @@ int HashMgr::add_word(const std::string& in_word,
                  !hp->astr && hp->alen == 0) {
         // word already exists with no flags, skip duplicate
         release_flags(hp->astr, hp->var & H_OPT_OWNFLAGS);
-        free(hp);
+        arena_free(hp);
         delete desc_copy;
         delete word_copy;
         return 0;
@@ -428,7 +437,7 @@ int HashMgr::add_word(const std::string& in_word,
   } else {
     // remove hidden onlyupcase homonym
     release_flags(hp->astr, hp->var & H_OPT_OWNFLAGS);
-    free(hp);
+    arena_free(hp);
   }
 
   delete desc_copy;
@@ -451,7 +460,8 @@ int HashMgr::add_hidden_capitalized_word(const std::string& word,
   if (((captype == HUHCAP) || (captype == HUHINITCAP) ||
        ((captype == ALLCAP) && (flagslen != 0))) &&
       !((flagslen != 0) && TESTAFF(flags, forbiddenword, flagslen))) {
-    unsigned short* flags2 = new unsigned short[flagslen + 1];
+    auto flags2 = (unsigned short*)arena_alloc((flagslen + 1) * sizeof(unsigned short),
+                                                alignof(unsigned short));
     flags2[flagslen] = ONLYUPCASEFLAG;
     if (flagslen) {
       memcpy(flags2, flags, flagslen * sizeof(unsigned short));
@@ -464,12 +474,12 @@ int HashMgr::add_hidden_capitalized_word(const std::string& word,
       mkallsmall_utf(w, langnum);
       mkinitcap_utf(w, langnum);
       u16_u8(st, w);
-      return add_word(st, wcl, flags2, flagslen + 1, dp, true, INITCAP, true);
+      return add_word(st, wcl, flags2, flagslen + 1, dp, true, INITCAP, false);
     } else {
       std::string new_word(word);
       mkallsmall(new_word, csconv);
       mkinitcap(new_word, csconv);
-      int ret = add_word(new_word, wcl, flags2, flagslen + 1, dp, true, INITCAP, true);
+      int ret = add_word(new_word, wcl, flags2, flagslen + 1, dp, true, INITCAP, false);
       return ret;
     }
   }
@@ -708,7 +718,7 @@ int HashMgr::load_tables(const char* tpath, const char* key) {
                            dict->getlinenum());
         }
       } else {
-        al = decode_flags(&flags, ap, dict);
+        al = decode_flags(&flags, ap, dict, /* arena = */ true);
         if (al == -1) {
           HUNSPELL_WARNING(stderr, "Can't allocate memory.\n");
           delete dict;
@@ -725,7 +735,8 @@ int HashMgr::load_tables(const char* tpath, const char* key) {
     int wcl = get_clen_and_captype(ts, &captype, workbuf);
     const std::string* dp_str = dp.empty() ? nullptr : &dp;
     // add the word and its index plus its capitalized form optionally
-    bool own = aliasf.empty();
+    // flags are arena-allocated, so own_aff must be false
+    bool own = false;
     if (add_word(ts, wcl, flags, al, dp_str, false, captype, own) ||
         add_hidden_capitalized_word(ts, wcl, flags, al, dp_str, captype)) {
       delete dict;
@@ -760,6 +771,15 @@ int HashMgr::hash(const char* word, size_t len) const {
 }
 
 int HashMgr::decode_flags(unsigned short** result, const std::string& flags, FileMgr* af) const {
+  return decode_flags(result, flags, af, /* arena = */ false);
+}
+
+int HashMgr::decode_flags(unsigned short** result, const std::string& flags, FileMgr* af, bool use_arena) const {
+  auto alloc = [&](int n) -> unsigned short* {
+    return use_arena ? (unsigned short*)this->arena_alloc(n * sizeof(unsigned short),
+                                                          alignof(unsigned short))
+                     : new unsigned short[n];
+  };
   int len;
   if (flags.empty()) {
     *result = nullptr;
@@ -772,7 +792,7 @@ int HashMgr::decode_flags(unsigned short** result, const std::string& flags, Fil
         HUNSPELL_WARNING(stderr, "error: line %d: bad flagvector\n",
                          af->getlinenum());
       len >>= 1;
-      *result = new unsigned short[len];
+      *result = alloc(len);
       for (int i = 0; i < len; i++) {
         unsigned short flag = ((unsigned short)((unsigned char)flags[i << 1]) << 8) |
                               ((unsigned short)((unsigned char)flags[(i << 1) | 1]));
@@ -784,7 +804,7 @@ int HashMgr::decode_flags(unsigned short** result, const std::string& flags, Fil
     case FLAG_NUM: {  // decimal numbers separated by comma (4521,23,233 -> 4521
                       // 23 233)
       len = int(1 + std::count_if(flags.begin(), flags.end(), [](char c) { return c == ','; }));
-      *result = new unsigned short[len];
+      *result = alloc(len);
       unsigned short* dest = *result;
       const char* src = flags.c_str();
       for (size_t p = 0; p < flags.size(); ++p) {
@@ -821,7 +841,7 @@ int HashMgr::decode_flags(unsigned short** result, const std::string& flags, Fil
       std::vector<w_char> w;
       u8_u16(w, flags);
       len = w.size();
-      *result = new unsigned short[len];
+      *result = alloc(len);
 #if defined(_WIN32) || (defined(__BYTE_ORDER__) && (__BYTE_ORDER__==__ORDER_LITTLE_ENDIAN__))  || defined(__LITTLE_ENDIAN__)
       memcpy(*result, w.data(), len * sizeof(unsigned short));
 #else
@@ -835,7 +855,7 @@ int HashMgr::decode_flags(unsigned short** result, const std::string& flags, Fil
     }
     default: {  // Ispell's one-character flags (erfg -> e r f g)
       len = flags.size();
-      *result = new unsigned short[len];
+      *result = alloc(len);
       unsigned short* dest = *result;
       for (const char flag : flags) {
         *dest = (unsigned char)flag;
@@ -1170,7 +1190,7 @@ bool HashMgr::parse_aliasf(const std::string& line, FileMgr* af) {
           case 1: {
             std::string piece(start_piece, iter);
             aliaslen =
-                (unsigned short)decode_flags(&alias, piece, af);
+                (unsigned short)decode_flags(&alias, piece, af, /* arena = */ true);
             std::sort(alias, alias + aliaslen);
             break;
           }
@@ -1183,7 +1203,7 @@ bool HashMgr::parse_aliasf(const std::string& line, FileMgr* af) {
     }
     if (!alias) {
       for (int k = 0; k < j; ++k) {
-        delete[] aliasf[k];
+        arena_free(aliasf[k]);
       }
       aliasf.clear();
       aliasflen.clear();
@@ -1282,8 +1302,10 @@ bool HashMgr::parse_aliasm(const std::string& line, FileMgr* af) {
                 reverseword(chunk);
             }
             size_t sl = chunk.size() + 1;
-            alias = new char[sl];
-            memcpy(alias, chunk.c_str(), sl);
+            alias = (char*)arena_alloc(sl, alignof(char));
+            if (alias) {
+              memcpy(alias, chunk.c_str(), sl);
+            }
             break;
           }
           default:
@@ -1295,7 +1317,7 @@ bool HashMgr::parse_aliasm(const std::string& line, FileMgr* af) {
     }
     if (!alias) {
       for (int k = 0; k < j; ++k) {
-        delete[] aliasm[k];
+        arena_free(aliasm[k]);
       }
       aliasm.clear();
       HUNSPELL_WARNING(stderr, "error: line %d: table is corrupt\n",
@@ -1412,4 +1434,47 @@ bool HashMgr::parse_reptable(const std::string& line, FileMgr* af) {
 // return replacing table
 const std::vector<replentry>& HashMgr::get_reptable() const {
   return reptable;
+}
+
+void* HashMgr::arena_alloc(size_t num_bytes, size_t alignment) const {
+  // Fixed-size 64KB chunks: small enough to avoid significant waste on small
+  // dictionaries, large enough to amortize per-chunk malloc overhead on large
+  // ones. make_unique throws std::bad_alloc on OOM.
+  static const size_t MIN_CHUNK_SIZE = 65536;
+  static const size_t MAX_ALIGNMENT = alignof(max_align_t);
+  // Chunk sizes are rounded up to MAX_ALIGNMENT below; with this invariant,
+  // any alignment that divides MAX_ALIGNMENT keeps aligned_offset within bounds.
+  assert(alignment > 0 && alignment <= MAX_ALIGNMENT);
+  // Pad the offset up to the requested alignment before placing this allocation.
+  // make_unique returns memory aligned for any scalar, so chunk-start is fine.
+  size_t aligned_offset = (current_chunk_offset + alignment - 1) & ~(alignment - 1);
+  if (arena.empty() || current_chunk_size - aligned_offset < num_bytes) {
+    // Round the new chunk's size up to a multiple of MAX_ALIGNMENT so that an
+    // oversized num_bytes (>= MIN_CHUNK_SIZE) cannot leave a non-aligned
+    // current_chunk_size that would later cause aligned_offset to overshoot.
+    // Allocate before mutating current_chunk_size so a throwing make_unique
+    // leaves the HashMgr in a consistent state.
+    size_t new_size = std::max(MIN_CHUNK_SIZE, num_bytes);
+    new_size = (new_size + MAX_ALIGNMENT - 1) & ~(MAX_ALIGNMENT - 1);
+    arena.push_back(std::make_unique<uint8_t[]>(new_size));
+    current_chunk_size = new_size;
+    aligned_offset = 0;
+  }
+
+  uint8_t* ptr = &arena.back()[aligned_offset];
+  current_chunk_offset = aligned_offset + num_bytes;
+  ++outstanding_arena_allocations;
+  return ptr;
+}
+
+void HashMgr::arena_free(void*) const {
+  // The arena vector owns all allocations and frees them in bulk at HashMgr
+  // destruction, so this is a no-op for the memory itself. The counter is a
+  // memory-safety check: more arena_free calls than arena_alloc calls would
+  // indicate a double-free or use-after-free in Hunspell. Abort hard rather
+  // than silently desynchronize tracking, even in release builds.
+  if (outstanding_arena_allocations == 0) {
+    std::abort();
+  }
+  --outstanding_arena_allocations;
 }

--- a/src/hunspell/hashmgr.hxx
+++ b/src/hunspell/hashmgr.hxx
@@ -72,6 +72,8 @@
 #define HASHMGR_HXX_
 
 #include <cstdio>
+#include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -154,6 +156,20 @@ class HashMgr {
   void remove_forbidden_flag(const std::string& word);
   void free_table();
   void release_flags(unsigned short* astr, bool owned);
+
+  // Only internal consumers are allowed to arena-allocate.
+  int decode_flags(unsigned short** result, const std::string& flags, FileMgr* af, bool use_arena) const;
+
+  // Bump-pointer arena for load-time hentry/flag/aliasm allocations. Freed in
+  // bulk at destruction. arena_free is a no-op that tracks outstanding allocs
+  // and aborts on underflow. Mutable so const decode_flags can arena-allocate.
+  void* arena_alloc(size_t num_bytes, size_t alignment) const;
+  void arena_free(void* ptr) const;
+
+  mutable std::vector<std::unique_ptr<uint8_t[]>> arena;
+  mutable size_t current_chunk_size = 0;
+  mutable size_t current_chunk_offset = 0;
+  mutable size_t outstanding_arena_allocations = 0;
 };
 
 #endif


### PR DESCRIPTION
As mentioned in #1120, this is the follow-up PR adding the arena allocator.

HashMgr currently calls `malloc`/`new[]` for every `hentry` struct, flag vector, and `aliasm` string
during dictionary load, then frees each one individually at destruction. For large dictionaries this
produces a lot of small live allocations (Bulgarian has ~700K entries) that fragment the heap and
leave it in poor shape for the rest of the process.

This replaces those load-time allocations with a simple bump-pointer arena: a per-`HashMgr` vector
of 64KB chunks freed in bulk at destruction. `arena_alloc` bumps a pointer within the current chunk
(allocating a new one when exhausted); `arena_free` is a no-op for memory but tracks an
outstanding-allocation counter and aborts on underflow as a double-free/use-after-free safeguard.

The arena covers:
- `hentry` structs (`add_word`)
- flag vectors decoded at load time (`decode_flags` with `use_arena=true`)
- `aliasm` strings (`parse_aliasm`)
- the extra `ONLYUPCASEFLAG` entry in `add_hidden_capitalized_word`

Runtime mutations (`add`, `add_with_affix`, `remove`) are unchanged: they continue to use
`new[]`/`delete[]` tracked by the `H_OPT_OWNFLAGS` bit and `release_flags`. Only load-time paths
use the arena.

In Firefox, where Hunspell runs in an RLBox wasm sandbox with a fixed linear-memory heap, this
reduces sandboxed memory consumption for en-US from ~65 to ~37 wasm pages and for Bulgarian from
~654 to ~494 pages (measured together with the hentry struct reorder from #1120). General-purpose
allocators should see proportional fragmentation improvements for large dictionaries.

`make check` passes 149/149.