### PR TITLE
Use static_cast instead of dynamic_cast when building the affix tree

### DIFF
--- a/src/hunspell/affixmgr.cxx
+++ b/src/hunspell/affixmgr.cxx
@@ -4737,9 +4737,9 @@ bool AffixMgr::parse_affix(const std::string& line,
   auto start = affentries.begin(), end = affentries.end();
   for (auto affentry = start; affentry != end; ++affentry) {
     if (at == 'P') {
-      build_pfxtree(dynamic_cast<PfxEntry*>(*affentry));
+      build_pfxtree(static_cast<PfxEntry*>(*affentry));
     } else {
-      build_sfxtree(dynamic_cast<SfxEntry*>(*affentry));
+      build_sfxtree(static_cast<SfxEntry*>(*affentry));
     }
   }
 


### PR DESCRIPTION
In `parse_affix`, the loop that hands each affentry to `build_pfxtree` or `build_sfxtree`
is already gated on the affix-type tag (`at == 'P'` for prefixes, otherwise suffix), so
the actual derived type at the cast site is unambiguous. The `dynamic_cast` is doing a
redundant RTTI lookup whose result the branch has already established.

Replacing it with `static_cast` drops the unnecessary runtime check and, more importantly,
lets Hunspell be built with `-fno-rtti`, which some downstream consumers (Firefox among
them) enable for code size. Without this change those consumers can't compile 1.7.3.

`make check` passes 149/149.