### PR TITLE
Gate std::bit_cast on __cpp_lib_bit_cast, matching w_char.hxx

### DIFF
--- a/src/hunspell/csutil.cxx
+++ b/src/hunspell/csutil.cxx
@@ -535,7 +535,7 @@ w_char upper_utf(w_char u, int langnum) {
 //but g++ remains in five instructions
 //maybe use inline asm for g++?
 
-#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
+#if (__cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)) && defined __cpp_lib_bit_cast && __cpp_lib_bit_cast >= 201806L
   return std::bit_cast<w_char>(unicodetoupper((unsigned short)u, langnum));
 #else
   const auto us = unicodetoupper((unsigned short)u, langnum);
@@ -559,7 +559,7 @@ w_char lower_utf(w_char u, int langnum) {
 //but g++ remains in five instructions
 //maybe use inline asm for g++?
 
-#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
+#if (__cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)) && defined __cpp_lib_bit_cast && __cpp_lib_bit_cast >= 201806L
   return std::bit_cast<w_char>(unicodetolower((unsigned short)u, langnum));
 #else
   const auto us = unicodetolower((unsigned short)u, langnum);

--- a/src/hunspell/hashmgr.cxx
+++ b/src/hunspell/hashmgr.cxx
@@ -965,7 +965,7 @@ std::string HashMgr::encode_flag(unsigned short f) const {
 
 #if defined(_WIN32) || (defined(__BYTE_ORDER__) && (__BYTE_ORDER__==__ORDER_LITTLE_ENDIAN__))  || defined(__LITTLE_ENDIAN__)
 
-#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
+#if (__cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)) && defined __cpp_lib_bit_cast && __cpp_lib_bit_cast >= 201806L
     auto wc = std::bit_cast<w_char>(f);
 #else
     w_char wc;


### PR DESCRIPTION
The `std::bit_cast` call sites in `csutil.cxx` (`upper_utf`, `lower_utf`) and `hashmgr.cxx`
(`encode_flag`) gate on `__cplusplus >= 202002L` alone, but the language mode doesn't guarantee
library support. libstdc++ 10 ships a partial `<bit>` header that omits `std::bit_cast`, so any
build using GCC 10's stdlib in C++20 mode (e.g. Firefox's static-analysis build, and presumably
some embedded toolchains) fails here with:

```
error: 'bit_cast' is not a member of 'std'
```

The corresponding call site in `w_char.hxx` already gates on `__cpp_lib_bit_cast` in addition to
the C++20 language check. This PR makes the other three sites consistent so the existing memcpy
fallback actually kicks in on older libraries.

LibreOffice has been carrying a downstream workaround for the same issue since 2023
(commit 00af391 by Stephan Bergmann); this fix would let them drop it.

`make check` passes 149/149.