### PR TITLE
hunspell.cxx: Add ".config/hunspell" to USEROOODIR to have a single place where a user can install a dictonaries

### DIFF
--- a/src/tools/hunspell.cxx
+++ b/src/tools/hunspell.cxx
@@ -70,6 +70,7 @@
 
 #define LIBDIR "C:\\Hunspell\\"
 #define USEROOODIR {                                    \
+  "AppData\\Roaming\\hunspell"    \
   "Application Data\\OpenOffice.org 2\\user\\wordbook", \
   "AppData\\Roaming\\LibreOffice\\4\\user\\wordbook"    \
 }
@@ -128,6 +129,7 @@
   "/usr/share/myspell/dicts:" \
   "/Library/Spelling"
 #define USEROOODIR {                       \
+  ".config/hunspell",                      \
   ".openoffice.org/3/user/wordbook",       \
   ".openoffice.org2/user/wordbook",        \
   ".openoffice.org2.0/user/wordbook",      \


### PR DESCRIPTION
Part of #1138

Currently a user have to install dictionaries in all programs that he use i.e. LibreOffice, Emasc etc.
The Hunspell _can_ find dictionaries installed to LibreOffice but other programs probably shouldn't deal with someone else app data folder.

Instead we may introduce a convention to search for dictionaries in the same folder:
1. Unix and Linux (and macOS?): `~/.config/hunspell`
2. Windows: `%APPDATA%\hunspell`

Please note that this is a `.config` (`AppData\Roaming`), not a `.cache` (`AppData\Local`) i.e. this dictionaries will be a subject for a backup.

It looks like for the macOS it's **already specified**  to `Library/Spelling`. I think that maybe for Unix and Linux we also should use `.config/spellcheck` to make it more clear for a user what it is.