### PR TITLE
tests: add regression test for capital sharp s (U+1E9E)

### DIFF
--- a/man/hunspell.5
+++ b/man/hunspell.5
@@ -651,7 +651,9 @@ WORDCHARS extends the tokenizer of the Hunspell command-line interface
 with additional word characters. For example, the dot, dash, n-dash,
 digits, and percent sign are word characters in Hungarian.
 .IP "CHECKSHARPS"
-SS letter pair in uppercased (German) words may be upper case sharp s (ß).
+SS letter pair in uppercased (German) words may be sharp s (ß), or
+capital sharp s (ẞ, U+1E9E), which German orthography has permitted in
+uppercased words since 2017.
 Hunspell can handle this special casing with the CHECKSHARPS
 declaration (see also KEEPCASE flag and tests/germancompounding example)
 in both spelling and suggestion.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -94,6 +94,7 @@ checkcompoundpattern4.dic \
 utfcompound.dic \
 checksharps.dic \
 checksharpsutf.dic \
+checksharpsutf2.dic \
 germancompounding.dic \
 germancompoundingold.dic \
 i35725.dic \
@@ -468,6 +469,10 @@ checksharpsutf.dic \
 checksharpsutf.good \
 checksharpsutf.sug \
 checksharpsutf.wrong \
+checksharpsutf2.aff \
+checksharpsutf2.dic \
+checksharpsutf2.good \
+checksharpsutf2.wrong \
 conditionalprefix.aff \
 conditionalprefix.dic \
 conditionalprefix.good \

--- a/tests/checksharpsutf2.aff
+++ b/tests/checksharpsutf2.aff
@@ -1,0 +1,5 @@
+# test capital sharp s (U+1E9E) in uppercased words, UTF-8
+SET UTF-8
+CHECKSHARPS
+WORDCHARS ßẞ
+KEEPCASE k

--- a/tests/checksharpsutf2.dic
+++ b/tests/checksharpsutf2.dic
@@ -1,0 +1,5 @@
+4
+Straße
+Außenmaße
+Großmann
+müßig/k

--- a/tests/checksharpsutf2.good
+++ b/tests/checksharpsutf2.good
@@ -1,0 +1,12 @@
+Straße
+STRASSE
+STRAẞE
+Außenmaße
+AUSSENMASSE
+AUẞENMAẞE
+Großmann
+GROSSMANN
+GROẞMANN
+müßig
+Müßig
+MÜSSIG

--- a/tests/checksharpsutf2.wrong
+++ b/tests/checksharpsutf2.wrong
@@ -1,0 +1,2 @@
+Straẞe
+MÜẞIG


### PR DESCRIPTION
<html><head></head><body><p>Closes #1139 (points 2 and 3).</p>
<p>Master already handles U+1E9E correctly — <code>utf_info.hxx</code> maps it to U+00DF since
4ad885b / 5aef308. Nothing in the test suite covers it, though: <code>grep -rl 'ẞ' tests/</code>
returns nothing. The fix came in as a side effect of the Unicode 16.0 refresh for an
unrelated Arabic combining-mark issue (#927), so it could disappear again just as
quietly.</p>
<h3>First commit — the test</h3>
<p><code>tests/checksharpsutf2</code> follows the existing <code>checksharps</code> / <code>checksharpsutf</code> pattern
and reuses their <code>CHECKSHARPS</code> + <code>KEEPCASE</code> setup. It pins three things:</p>

Case | Expectation
-- | --
STRASSE, STRAẞE, AUẞENMAẞE, GROẞMANN | accepted — uppercased forms may use SS or ẞ
Straẞe | rejected — ẞ in a mixed-case word is still wrong
MÜSSIG accepted, MÜẞIG rejected | KEEPCASE semantics unchanged: uppercased KEEPCASE words may still only use SS


<p>The third row is the one I would most want locked in. It shows the U+1E9E mapping did
not loosen the KEEPCASE rule documented in <code>hunspell.5</code>, and it is the part most likely
to break silently if the casing tables are regenerated again.</p>
<p>Verified both ways. Against master:</p>
<pre><code>$ make -C tests check TESTS=checksharpsutf2.dic
PASS: checksharpsutf2.dic
</code></pre>
<p>And against v1.7.3 built from the tag, which is the version LibreOffice pins in
<code>download.lst</code>:</p>
<pre><code>$ git worktree add ../hunspell-1.7.3 v1.7.3
$ cd ../hunspell-1.7.3 &amp;&amp; autoreconf -fi &amp;&amp; ./configure &amp;&amp; make
$ cp ../hunspell/tests/checksharpsutf2.* tests/ &amp;&amp; cd tests
$ ./test.sh checksharpsutf2.dic
Fail in checksharpsutf2.good. Good words recognised as wrong:
STRAẞE
AUẞENMAẞE
GROẞMANN
</code></pre>
<p>So the test does what a regression test should: it fails on the last release and passes
on master. Full suite on master with the change: 0 failures, 0 errors, 1 skip.</p>
<p>As a data point for how far this reaches: Ubuntu 26.04 still ships
<code>hunspell 1.7.2+really1.7.2-11</code>, so the newest Ubuntu release carries neither the fix
nor even 1.7.3.</p>
<p>No <code>.sug</code> file — I deliberately left suggestion output unasserted, since it is the more
brittle part and the point here is the casing behaviour.</p>
<h3>Second commit — man page wording</h3>
<p>Separate commit, easy to drop if you disagree. The <code>CHECKSHARPS</code> paragraph called ß the
"upper case sharp s", which predates U+1E9E existing. Since uppercased words may now
contain either form, both are named.</p>
<p>I left the KEEPCASE note further up untouched. It states that uppercased forms of
KEEPCASE words may only contain SS, and that is still exactly what master does — the
new test asserts it.</p>
<h3>Open question, not part of this PR</h3>
<p>U+00DF has <code>cupper = 0x0000</code>, so suggestions for all-caps misspellings only ever offer
the SS form:</p>
<pre><code>$ echo 'GROßMAN' | hunspell -i UTF-8 -d de_DE -a
&amp; GROßMAN 9 0: GROSS MAN, GROSSMAIN, GROSSMANN, GROSSSAN, ...
</code></pre>
<p>For a surname <code>GROSSMANN</code> and <code>GROẞMANN</code> are different names. SS remains a fully
sanctioned spelling, so this may well be intended — I did not want to change suggestion
behaviour on a guess. Happy to follow up if you think it is worth changing.</p>
<p>Point 1 of #1139, a release carrying the fix, is untouched by this PR and still the
part that actually reaches users.</p></body></html>